### PR TITLE
fail if table already exists in order to merge the data

### DIFF
--- a/oeds/crawler/entsoe_crawler.py
+++ b/oeds/crawler/entsoe_crawler.py
@@ -203,7 +203,7 @@ class EntsoeCrawler(ContinuousCrawler):
             data["country"] = country
             try:
                 with self.engine.begin() as conn:
-                    data.to_sql(proc.__name__, conn, if_exists="append")
+                    data.to_sql(proc.__name__, conn, if_exists="fail")
             except Exception as e:
                 with self.engine.begin() as conn:
                     log.info(f"handling {repr(e)} by concat")


### PR DESCRIPTION
Trigger a fail if the table already exists, so the exception handling can merge the two tables and prevent duplicated values @maurerle 