### PR TITLE
Switch from eager to lazy loading for crawlers module

### DIFF
--- a/oeds/crawler/__init__.py
+++ b/oeds/crawler/__init__.py
@@ -2,58 +2,73 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from oeds.base_crawler import BaseCrawler
-from oeds.crawler.chargepoint import ChargepointDownloader
-from oeds.crawler.e2watch import E2WatchCrawler
-from oeds.crawler.ecmwf_crawler import EcmwfCrawler
-from oeds.crawler.entsoe_crawler import EntsoeCrawler
-from oeds.crawler.entsog import EntsogCrawler
-from oeds.crawler.eon_grid_fees import EonGridFeeCrawler
-from oeds.crawler.eview import EViewCrawler
-from oeds.crawler.fernwaerme_preisuebersicht import FWCrawler
-from oeds.crawler.frequency import FrequencyCrawler
-from oeds.crawler.gie_crawler import GieCrawler
-from oeds.crawler.instrat_pl import InstratPlCrawler
-from oeds.crawler.jao_crawler import JaoCrawler
-from oeds.crawler.jrc_idees import JrcIdeesCrawler
-from oeds.crawler.ladesaeulenregister import LadesaeulenregisterCrawler
-from oeds.crawler.londondatastore import LondonLoadData
-from oeds.crawler.mastr import MastrDownloader
-from oeds.crawler.netztransparenz import NetztransparenzCrawler
-from oeds.crawler.ninja import NinjaCrawler
-from oeds.crawler.nuts_mapper import NutsCrawler
-from oeds.crawler.oep import OepCrawler
-from oeds.crawler.opec import OpecDownloader
-from oeds.crawler.opsd import OpsdCrawler
-from oeds.crawler.smard import SmardCrawler
-from oeds.crawler.synpro import SynproLoadProfileCrawler
-from oeds.crawler.vea_industrial_load_profiles import IndustrialLoadProfileCrawler
+from importlib import import_module
 
-crawlers: dict[str, type[BaseCrawler]] = {
-    "public": NutsCrawler,
-    "chargepoint": ChargepointDownloader,
-    "e2watch": E2WatchCrawler,
-    "ecmwf": EcmwfCrawler,
-    "eon_grid_fees": EonGridFeeCrawler,
-    "entsoe": EntsoeCrawler,
-    "entsog": EntsogCrawler,
-    "eview": EViewCrawler,
-    "fernwaerme_preisuebersicht": FWCrawler,
-    "frequency": FrequencyCrawler,
-    "gie": GieCrawler,
-    "instrat_pl": InstratPlCrawler,
-    "jao": JaoCrawler,
-    "jrc_idees": JrcIdeesCrawler,
-    "ladesaeulenregister": LadesaeulenregisterCrawler,
-    "londondatastore": LondonLoadData,
-    "mastr": MastrDownloader,
-    "netztransparenz": NetztransparenzCrawler,
-    "ninja": NinjaCrawler,
-    "oep": OepCrawler,
-    "opec": OpecDownloader,
-    "opsd": OpsdCrawler,
-    "smard": SmardCrawler,
-    "synpro": SynproLoadProfileCrawler,
-    "vea_industrial_load_profiles": IndustrialLoadProfileCrawler,
-    "weather": EcmwfCrawler,
+from oeds.base_crawler import BaseCrawler
+
+_CRAWLER_MODULES: dict[str, tuple[str, str]] = {
+    "public": ("oeds.crawler.nuts_mapper", "NutsCrawler"),
+    "chargepoint": ("oeds.crawler.chargepoint", "ChargepointDownloader"),
+    "e2watch": ("oeds.crawler.e2watch", "E2WatchCrawler"),
+    "ecmwf": ("oeds.crawler.ecmwf_crawler", "EcmwfCrawler"),
+    "eon_grid_fees": ("oeds.crawler.eon_grid_fees", "EonGridFeeCrawler"),
+    "entsoe": ("oeds.crawler.entsoe_crawler", "EntsoeCrawler"),
+    "entsog": ("oeds.crawler.entsog", "EntsogCrawler"),
+    "eview": ("oeds.crawler.eview", "EViewCrawler"),
+    "fernwaerme_preisuebersicht": (
+        "oeds.crawler.fernwaerme_preisuebersicht",
+        "FWCrawler",
+    ),
+    "frequency": ("oeds.crawler.frequency", "FrequencyCrawler"),
+    "gie": ("oeds.crawler.gie_crawler", "GieCrawler"),
+    "instrat_pl": ("oeds.crawler.instrat_pl", "InstratPlCrawler"),
+    "jao": ("oeds.crawler.jao_crawler", "JaoCrawler"),
+    "jrc_idees": ("oeds.crawler.jrc_idees", "JrcIdeesCrawler"),
+    "ladesaeulenregister": (
+        "oeds.crawler.ladesaeulenregister",
+        "LadesaeulenregisterCrawler",
+    ),
+    "londondatastore": ("oeds.crawler.londondatastore", "LondonLoadData"),
+    "mastr": ("oeds.crawler.mastr", "MastrDownloader"),
+    "netzentgelte": ("oeds.crawler.netzentgelte", "NetzentgeltCrawler"),
+    "netztransparenz": ("oeds.crawler.netztransparenz", "NetztransparenzCrawler"),
+    "ninja": ("oeds.crawler.ninja", "NinjaCrawler"),
+    "oep": ("oeds.crawler.oep", "OepCrawler"),
+    "opec": ("oeds.crawler.opec", "OpecDownloader"),
+    "opsd": ("oeds.crawler.opsd", "OpsdCrawler"),
+    "smard": ("oeds.crawler.smard", "SmardCrawler"),
+    "synpro": ("oeds.crawler.synpro", "SynproLoadProfileCrawler"),
+    "vea_industrial_load_profiles": (
+        "oeds.crawler.vea_industrial_load_profiles",
+        "IndustrialLoadProfileCrawler",
+    ),
+    "weather": ("oeds.crawler.ecmwf_crawler", "EcmwfCrawler"),
 }
+
+
+class _CrawlerRegistry:
+    def __init__(self, modules: dict[str, tuple[str, str]]):
+        self._modules = modules
+        self._loaded: dict[str, type[BaseCrawler]] = {}
+
+    def keys(self):
+        return self._modules.keys()
+
+    def __iter__(self):
+        return iter(self._modules)
+
+    def items(self):
+        for name in self._modules:
+            yield name, self[name]
+
+    def __getitem__(self, name: str) -> type[BaseCrawler]:
+        if name not in self._modules:
+            raise KeyError(name)
+        if name not in self._loaded:
+            module_name, class_name = self._modules[name]
+            module = import_module(module_name)
+            self._loaded[name] = getattr(module, class_name)
+        return self._loaded[name]
+
+
+crawlers: _CrawlerRegistry = _CrawlerRegistry(_CRAWLER_MODULES)


### PR DESCRIPTION
### **User description**
fixes #45 

Crawler-modules will only be loaded when needed, not by default.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Lazy-load crawler modules on access

- Avoid optional dependency import failures

- Add registry mapping for module/class names


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cli["CLI selects crawler(s)"] 
  registry["_CrawlerRegistry"] 
  mapping["_CRAWLER_MODULES mapping"] 
  importer["import_module() on demand"] 
  crawler["Selected crawler class loaded"]
  cli -- "access `crawlers[name]`" --> registry
  registry -- "lookup module/class" --> mapping
  registry -- "lazy import" --> importer
  importer -- "return class" --> crawler
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Replace eager imports with lazy crawler registry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

oeds/crawler/__init__.py

<ul><li>Introduce <code>_CRAWLER_MODULES</code> mapping of crawler names<br> <li> Add <code>_CrawlerRegistry</code> to import modules on demand<br> <li> Replace eagerly imported <code>crawlers</code> dict with registry<br> <li> Add <code>netzentgelte</code> crawler entry to registry</ul>


</details>


  </td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/48/files#diff-0f49a621903cf626c2af77f6b268377b73179c8d55bfb5a4887d0c9121b3f165">+68/-53</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

