### PR TITLE
Add crawling for grid fees for different german cities

### DIFF
--- a/oeds/crawler/__init__.py
+++ b/oeds/crawler/__init__.py
@@ -2,73 +2,60 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from importlib import import_module
-
 from oeds.base_crawler import BaseCrawler
+from oeds.crawler.chargepoint import ChargepointDownloader
+from oeds.crawler.e2watch import E2WatchCrawler
+from oeds.crawler.ecmwf_crawler import EcmwfCrawler
+from oeds.crawler.entsoe_crawler import EntsoeCrawler
+from oeds.crawler.entsog import EntsogCrawler
+from oeds.crawler.eon_grid_fees import EonGridFeeCrawler
+from oeds.crawler.eview import EViewCrawler
+from oeds.crawler.fernwaerme_preisuebersicht import FWCrawler
+from oeds.crawler.frequency import FrequencyCrawler
+from oeds.crawler.gie_crawler import GieCrawler
+from oeds.crawler.instrat_pl import InstratPlCrawler
+from oeds.crawler.jao_crawler import JaoCrawler
+from oeds.crawler.jrc_idees import JrcIdeesCrawler
+from oeds.crawler.ladesaeulenregister import LadesaeulenregisterCrawler
+from oeds.crawler.londondatastore import LondonLoadData
+from oeds.crawler.mastr import MastrDownloader
+from oeds.crawler.netzentgelte import NetzentgeltCrawler
+from oeds.crawler.netztransparenz import NetztransparenzCrawler
+from oeds.crawler.ninja import NinjaCrawler
+from oeds.crawler.nuts_mapper import NutsCrawler
+from oeds.crawler.oep import OepCrawler
+from oeds.crawler.opec import OpecDownloader
+from oeds.crawler.opsd import OpsdCrawler
+from oeds.crawler.smard import SmardCrawler
+from oeds.crawler.synpro import SynproLoadProfileCrawler
+from oeds.crawler.vea_industrial_load_profiles import IndustrialLoadProfileCrawler
 
-_CRAWLER_MODULES: dict[str, tuple[str, str]] = {
-    "public": ("oeds.crawler.nuts_mapper", "NutsCrawler"),
-    "chargepoint": ("oeds.crawler.chargepoint", "ChargepointDownloader"),
-    "e2watch": ("oeds.crawler.e2watch", "E2WatchCrawler"),
-    "ecmwf": ("oeds.crawler.ecmwf_crawler", "EcmwfCrawler"),
-    "eon_grid_fees": ("oeds.crawler.eon_grid_fees", "EonGridFeeCrawler"),
-    "entsoe": ("oeds.crawler.entsoe_crawler", "EntsoeCrawler"),
-    "entsog": ("oeds.crawler.entsog", "EntsogCrawler"),
-    "eview": ("oeds.crawler.eview", "EViewCrawler"),
-    "fernwaerme_preisuebersicht": (
-        "oeds.crawler.fernwaerme_preisuebersicht",
-        "FWCrawler",
-    ),
-    "frequency": ("oeds.crawler.frequency", "FrequencyCrawler"),
-    "gie": ("oeds.crawler.gie_crawler", "GieCrawler"),
-    "instrat_pl": ("oeds.crawler.instrat_pl", "InstratPlCrawler"),
-    "jao": ("oeds.crawler.jao_crawler", "JaoCrawler"),
-    "jrc_idees": ("oeds.crawler.jrc_idees", "JrcIdeesCrawler"),
-    "ladesaeulenregister": (
-        "oeds.crawler.ladesaeulenregister",
-        "LadesaeulenregisterCrawler",
-    ),
-    "londondatastore": ("oeds.crawler.londondatastore", "LondonLoadData"),
-    "mastr": ("oeds.crawler.mastr", "MastrDownloader"),
-    "netzentgelte": ("oeds.crawler.netzentgelte", "NetzentgeltCrawler"),
-    "netztransparenz": ("oeds.crawler.netztransparenz", "NetztransparenzCrawler"),
-    "ninja": ("oeds.crawler.ninja", "NinjaCrawler"),
-    "oep": ("oeds.crawler.oep", "OepCrawler"),
-    "opec": ("oeds.crawler.opec", "OpecDownloader"),
-    "opsd": ("oeds.crawler.opsd", "OpsdCrawler"),
-    "smard": ("oeds.crawler.smard", "SmardCrawler"),
-    "synpro": ("oeds.crawler.synpro", "SynproLoadProfileCrawler"),
-    "vea_industrial_load_profiles": (
-        "oeds.crawler.vea_industrial_load_profiles",
-        "IndustrialLoadProfileCrawler",
-    ),
-    "weather": ("oeds.crawler.ecmwf_crawler", "EcmwfCrawler"),
+crawlers: dict[str, type[BaseCrawler]] = {
+    "public": NutsCrawler,
+    "chargepoint": ChargepointDownloader,
+    "e2watch": E2WatchCrawler,
+    "ecmwf": EcmwfCrawler,
+    "eon_grid_fees": EonGridFeeCrawler,
+    "entsoe": EntsoeCrawler,
+    "entsog": EntsogCrawler,
+    "eview": EViewCrawler,
+    "fernwaerme_preisuebersicht": FWCrawler,
+    "frequency": FrequencyCrawler,
+    "gie": GieCrawler,
+    "instrat_pl": InstratPlCrawler,
+    "jao": JaoCrawler,
+    "jrc_idees": JrcIdeesCrawler,
+    "ladesaeulenregister": LadesaeulenregisterCrawler,
+    "londondatastore": LondonLoadData,
+    "mastr": MastrDownloader,
+    "netzentgelte": NetzentgeltCrawler,
+    "netztransparenz": NetztransparenzCrawler,
+    "ninja": NinjaCrawler,
+    "oep": OepCrawler,
+    "opec": OpecDownloader,
+    "opsd": OpsdCrawler,
+    "smard": SmardCrawler,
+    "synpro": SynproLoadProfileCrawler,
+    "vea_industrial_load_profiles": IndustrialLoadProfileCrawler,
+    "weather": EcmwfCrawler,
 }
-
-
-class _CrawlerRegistry:
-    def __init__(self, modules: dict[str, tuple[str, str]]):
-        self._modules = modules
-        self._loaded: dict[str, type[BaseCrawler]] = {}
-
-    def keys(self):
-        return self._modules.keys()
-
-    def __iter__(self):
-        return iter(self._modules)
-
-    def items(self):
-        for name in self._modules:
-            yield name, self[name]
-
-    def __getitem__(self, name: str) -> type[BaseCrawler]:
-        if name not in self._modules:
-            raise KeyError(name)
-        if name not in self._loaded:
-            module_name, class_name = self._modules[name]
-            module = import_module(module_name)
-            self._loaded[name] = getattr(module, class_name)
-        return self._loaded[name]
-
-
-crawlers: _CrawlerRegistry = _CrawlerRegistry(_CRAWLER_MODULES)

--- a/oeds/crawler/__init__.py
+++ b/oeds/crawler/__init__.py
@@ -2,58 +2,73 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from oeds.base_crawler import BaseCrawler
-from oeds.crawler.chargepoint import ChargepointDownloader
-from oeds.crawler.e2watch import E2WatchCrawler
-from oeds.crawler.ecmwf_crawler import EcmwfCrawler
-from oeds.crawler.entsoe_crawler import EntsoeCrawler
-from oeds.crawler.entsog import EntsogCrawler
-from oeds.crawler.eon_grid_fees import EonGridFeeCrawler
-from oeds.crawler.eview import EViewCrawler
-from oeds.crawler.fernwaerme_preisuebersicht import FWCrawler
-from oeds.crawler.frequency import FrequencyCrawler
-from oeds.crawler.gie_crawler import GieCrawler
-from oeds.crawler.instrat_pl import InstratPlCrawler
-from oeds.crawler.jao_crawler import JaoCrawler
-from oeds.crawler.jrc_idees import JrcIdeesCrawler
-from oeds.crawler.ladesaeulenregister import LadesaeulenregisterCrawler
-from oeds.crawler.londondatastore import LondonLoadData
-from oeds.crawler.mastr import MastrDownloader
-from oeds.crawler.netztransparenz import NetztransparenzCrawler
-from oeds.crawler.ninja import NinjaCrawler
-from oeds.crawler.nuts_mapper import NutsCrawler
-from oeds.crawler.oep import OepCrawler
-from oeds.crawler.opec import OpecDownloader
-from oeds.crawler.opsd import OpsdCrawler
-from oeds.crawler.smard import SmardCrawler
-from oeds.crawler.synpro import SynproLoadProfileCrawler
-from oeds.crawler.vea_industrial_load_profiles import IndustrialLoadProfileCrawler
+from importlib import import_module
 
-crawlers: dict[str, type[BaseCrawler]] = {
-    "public": NutsCrawler,
-    "chargepoint": ChargepointDownloader,
-    "e2watch": E2WatchCrawler,
-    "ecmwf": EcmwfCrawler,
-    "eon_grid_fees": EonGridFeeCrawler,
-    "entsoe": EntsoeCrawler,
-    "entsog": EntsogCrawler,
-    "eview": EViewCrawler,
-    "fernwaerme_preisuebersicht": FWCrawler,
-    "frequency": FrequencyCrawler,
-    "gie": GieCrawler,
-    "instrat_pl": InstratPlCrawler,
-    "jao": JaoCrawler,
-    "jrc_idees": JrcIdeesCrawler,
-    "ladesaeulenregister": LadesaeulenregisterCrawler,
-    "londondatastore": LondonLoadData,
-    "mastr": MastrDownloader,
-    "netztransparenz": NetztransparenzCrawler,
-    "ninja": NinjaCrawler,
-    "oep": OepCrawler,
-    "opec": OpecDownloader,
-    "opsd": OpsdCrawler,
-    "smard": SmardCrawler,
-    "synpro": SynproLoadProfileCrawler,
-    "vea_industrial_load_profiles": IndustrialLoadProfileCrawler,
-    "weather": EcmwfCrawler,
+from oeds.base_crawler import BaseCrawler
+
+_CRAWLER_MODULES: dict[str, tuple[str, str]] = {
+    "public": ("oeds.crawler.nuts_mapper", "NutsCrawler"),
+    "chargepoint": ("oeds.crawler.chargepoint", "ChargepointDownloader"),
+    "e2watch": ("oeds.crawler.e2watch", "E2WatchCrawler"),
+    "ecmwf": ("oeds.crawler.ecmwf_crawler", "EcmwfCrawler"),
+    "eon_grid_fees": ("oeds.crawler.eon_grid_fees", "EonGridFeeCrawler"),
+    "entsoe": ("oeds.crawler.entsoe_crawler", "EntsoeCrawler"),
+    "entsog": ("oeds.crawler.entsog", "EntsogCrawler"),
+    "eview": ("oeds.crawler.eview", "EViewCrawler"),
+    "fernwaerme_preisuebersicht": (
+        "oeds.crawler.fernwaerme_preisuebersicht",
+        "FWCrawler",
+    ),
+    "frequency": ("oeds.crawler.frequency", "FrequencyCrawler"),
+    "gie": ("oeds.crawler.gie_crawler", "GieCrawler"),
+    "instrat_pl": ("oeds.crawler.instrat_pl", "InstratPlCrawler"),
+    "jao": ("oeds.crawler.jao_crawler", "JaoCrawler"),
+    "jrc_idees": ("oeds.crawler.jrc_idees", "JrcIdeesCrawler"),
+    "ladesaeulenregister": (
+        "oeds.crawler.ladesaeulenregister",
+        "LadesaeulenregisterCrawler",
+    ),
+    "londondatastore": ("oeds.crawler.londondatastore", "LondonLoadData"),
+    "mastr": ("oeds.crawler.mastr", "MastrDownloader"),
+    "netzentgelte": ("oeds.crawler.netzentgelte", "NetzentgeltCrawler"),
+    "netztransparenz": ("oeds.crawler.netztransparenz", "NetztransparenzCrawler"),
+    "ninja": ("oeds.crawler.ninja", "NinjaCrawler"),
+    "oep": ("oeds.crawler.oep", "OepCrawler"),
+    "opec": ("oeds.crawler.opec", "OpecDownloader"),
+    "opsd": ("oeds.crawler.opsd", "OpsdCrawler"),
+    "smard": ("oeds.crawler.smard", "SmardCrawler"),
+    "synpro": ("oeds.crawler.synpro", "SynproLoadProfileCrawler"),
+    "vea_industrial_load_profiles": (
+        "oeds.crawler.vea_industrial_load_profiles",
+        "IndustrialLoadProfileCrawler",
+    ),
+    "weather": ("oeds.crawler.ecmwf_crawler", "EcmwfCrawler"),
 }
+
+
+class _CrawlerRegistry:
+    def __init__(self, modules: dict[str, tuple[str, str]]):
+        self._modules = modules
+        self._loaded: dict[str, type[BaseCrawler]] = {}
+
+    def keys(self):
+        return self._modules.keys()
+
+    def __iter__(self):
+        return iter(self._modules)
+
+    def items(self):
+        for name in self._modules:
+            yield name, self[name]
+
+    def __getitem__(self, name: str) -> type[BaseCrawler]:
+        if name not in self._modules:
+            raise KeyError(name)
+        if name not in self._loaded:
+            module_name, class_name = self._modules[name]
+            module = import_module(module_name)
+            self._loaded[name] = getattr(module, class_name)
+        return self._loaded[name]
+
+
+crawlers: _CrawlerRegistry = _CrawlerRegistry(_CRAWLER_MODULES)

--- a/oeds/crawler/netzentgelte/__init__.py
+++ b/oeds/crawler/netzentgelte/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Christoph Komanns
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from oeds.crawler.netzentgelte.crawler import NetzentgeltCrawler, metadata_info
+
+__all__ = ["NetzentgeltCrawler", "metadata_info"]

--- a/oeds/crawler/netzentgelte/adapters/__init__.py
+++ b/oeds/crawler/netzentgelte/adapters/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Christoph Komanns
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/oeds/crawler/netzentgelte/adapters/_common.py
+++ b/oeds/crawler/netzentgelte/adapters/_common.py
@@ -18,7 +18,6 @@ here:
 This module starts with "_" and is therefore NOT loaded as an adapter by the
 pipeline.
 """
-
 from __future__ import annotations
 
 import re

--- a/oeds/crawler/netzentgelte/adapters/_common.py
+++ b/oeds/crawler/netzentgelte/adapters/_common.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Christoph Komanns
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Small shared helper functions for the VNB adapters.
+
+Deliberately minimal: there is NO universal parser for all grid operators (see
+README, section "Why no single parser for all"). Each adapter remains
+responsible for its own PDF layout and only uses what is truly common from
+here:
+
+- German/Dutch number format (thousands separator, decimal comma),
+- extracting a section between two text markers,
+- collecting table data rows by the number of numbers per line (robust against
+  pdfplumber placing row labels before or after the number columns).
+
+This module starts with "_" and is therefore NOT loaded as an adapter by the
+pipeline.
+"""
+from __future__ import annotations
+
+import re
+
+# e.g. "1.971,0398", "150,00", "-137,13", "11,06315"
+_DECIMAL_RE = re.compile(r"-?\d{1,3}(?:\.\d{3})*,\d+")
+
+
+def de_float(s: str) -> float:
+    """German number format -> float ("1.234,56" -> 1234.56)."""
+    return float(s.replace(".", "").replace(",", "."))
+
+
+def decimals(line: str) -> list[float]:
+    """All decimal numbers in a line as floats, in reading order.
+
+    Integers without a decimal comma (e.g. the "2.500" in "< 2.500 h/a") are
+    deliberately ignored - only real price values with fractional digits count.
+    """
+    return [de_float(m) for m in _DECIMAL_RE.findall(line)]
+
+
+def slice_between(text: str, start: str, end: str | None = None) -> str:
+    """Section between the first occurrence of `start` and the first subsequent
+    occurrence of `end` (or until end of text if end=None)."""
+    i = text.find(start)
+    if i < 0:
+        return ""
+    i += len(start)
+    if end is None:
+        return text[i:]
+    j = text.find(end, i)
+    return text[i:] if j < 0 else text[i:j]
+
+
+def numeric_rows(section: str, count: int, min_numbers: int = 4) -> list[list[float]]:
+    """The first `count` lines from `section` that contain at least `min_numbers`
+    decimal numbers - returned as a list of their numbers per line.
+
+    This reliably extracts tables such as the annual capacity price system even
+    when the voltage level label is on its own line before or after the numbers:
+    the order of data rows is preserved.
+    """
+    rows: list[list[float]] = []
+    for line in section.splitlines():
+        nums = decimals(line)
+        if len(nums) >= min_numbers:
+            rows.append(nums)
+            if len(rows) >= count:
+                break
+    return rows

--- a/oeds/crawler/netzentgelte/adapters/_common.py
+++ b/oeds/crawler/netzentgelte/adapters/_common.py
@@ -18,6 +18,7 @@ here:
 This module starts with "_" and is therefore NOT loaded as an adapter by the
 pipeline.
 """
+
 from __future__ import annotations
 
 import re

--- a/oeds/crawler/netzentgelte/adapters/enexis_heerlen.py
+++ b/oeds/crawler/netzentgelte/adapters/enexis_heerlen.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Christoph Komanns
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Adapter for Enexis Netbeheer B.V. - distribution system operator for Heerlen (NL,
+province of Limburg).
+
+IMPORTANT CONTEXT (please read): Heerlen is in the Netherlands. The Dutch grid
+fee system is NOT comparable to the German one and only approximately fits the
+(Germany-centric) schema of this tool:
+
+- For households ("kleinverbruik", connection up to 3x80 A) there is NO energy
+  price in ct/kWh. Grid costs are a pure CAPACITY CHARGE: a fixed annual amount
+  per connection size (aansluitwaarde, in amperes), regulated by the ACM.
+- There are NO household fees tiered by voltage level.
+- Published amounts INCLUDE 21% btw (VAT), not net as with German VNBs.
+
+This adapter therefore maps the standard household connection
+(">1 x 10 t/m 3 x 25 A", the typical house connection) as ONE entry:
+- netzebene = Niederspannung, tarifsystem = Grundpreis_Arbeitspreis
+- grundpreis_eur_jahr = annual grid costs for this connection (incl. btw)
+- arbeitspreis_ct_kwh = None (does not exist for kleinverbruik)
+- netto_oder_brutto = "brutto"
+
+German columns (capacity price, utilisation hours, voltage level tiers) remain
+empty because they simply do not exist here. A direct numerical comparison with
+German cities is therefore only of limited use.
+
+Verified against: enexis.nl, tariff sheet "Elektriciteit | Kleinverbruik",
+Netbeheerkosten 1 januari 2026, Versie 1.0.
+"""
+from __future__ import annotations
+
+import re
+
+from ..schema import NetzentgeltEintrag
+from . import _common as c
+
+NETZBETREIBER = "Enexis Netbeheer B.V."
+
+
+def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
+    out: list[NetzentgeltEintrag] = []
+    m = re.search(r"Versie\s+([\d.]+)", text)
+    stand = f"Versie {m.group(1)}" if m else None
+
+    # Table "Aansluiting met elektriciteitsmeter": per connection size
+    # Per dag / Per maand / Per jaar (incl. btw). We use the standard household
+    # connection 3 x 25 A and take the annual amount (last number).
+    sec = c.slice_between(text, "Aansluiting met elektriciteitsmeter", "Aansluiting zonder")
+    for line in sec.splitlines():
+        if re.search(r"3\s*[\u00d7x]\s*25", line):  # "3 x 25" or "3 × 25"
+            nums = c.decimals(line)
+            if nums:
+                out.append(NetzentgeltEintrag(
+                    stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
+                    netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
+                    benutzungsdauer_klasse=None,
+                    grundpreis_eur_jahr=nums[-1], arbeitspreis_ct_kwh=None,
+                    leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
+                    jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+                    netto_oder_brutto="brutto", mwst_prozent=21.0,
+                ))
+            break
+
+    return out

--- a/oeds/crawler/netzentgelte/adapters/enexis_heerlen.py
+++ b/oeds/crawler/netzentgelte/adapters/enexis_heerlen.py
@@ -30,7 +30,6 @@ German cities is therefore only of limited use.
 Verified against: enexis.nl, tariff sheet "Elektriciteit | Kleinverbruik",
 Netbeheerkosten 1 januari 2026, Versie 1.0.
 """
-
 from __future__ import annotations
 
 import re
@@ -41,9 +40,7 @@ from . import _common as c
 NETZBETREIBER = "Enexis Netbeheer B.V."
 
 
-def parse(
-    text: str, stadt: str, jahr: int, quelle_url: str
-) -> list[NetzentgeltEintrag]:
+def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
     out: list[NetzentgeltEintrag] = []
     m = re.search(r"Versie\s+([\d.]+)", text)
     stand = f"Versie {m.group(1)}" if m else None
@@ -51,32 +48,20 @@ def parse(
     # Table "Aansluiting met elektriciteitsmeter": per connection size
     # Per dag / Per maand / Per jaar (incl. btw). We use the standard household
     # connection 3 x 25 A and take the annual amount (last number).
-    sec = c.slice_between(
-        text, "Aansluiting met elektriciteitsmeter", "Aansluiting zonder"
-    )
+    sec = c.slice_between(text, "Aansluiting met elektriciteitsmeter", "Aansluiting zonder")
     for line in sec.splitlines():
         if re.search(r"3\s*[\u00d7x]\s*25", line):  # "3 x 25" or "3 × 25"
             nums = c.decimals(line)
             if nums:
-                out.append(
-                    NetzentgeltEintrag(
-                        stadt=stadt,
-                        netzbetreiber=NETZBETREIBER,
-                        netzbetreiber_typ="Verteilnetz",
-                        netzebene="Niederspannung",
-                        tarifsystem="Grundpreis_Arbeitspreis",
-                        benutzungsdauer_klasse=None,
-                        grundpreis_eur_jahr=nums[-1],
-                        arbeitspreis_ct_kwh=None,
-                        leistungspreis_eur_kw_jahr=None,
-                        leistungspreis_eur_kw_monat=None,
-                        jahr=jahr,
-                        stand_dokument=stand,
-                        quelle_url=quelle_url,
-                        netto_oder_brutto="brutto",
-                        mwst_prozent=21.0,
-                    )
-                )
+                out.append(NetzentgeltEintrag(
+                    stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
+                    netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
+                    benutzungsdauer_klasse=None,
+                    grundpreis_eur_jahr=nums[-1], arbeitspreis_ct_kwh=None,
+                    leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
+                    jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+                    netto_oder_brutto="brutto", mwst_prozent=21.0,
+                ))
             break
 
     return out

--- a/oeds/crawler/netzentgelte/adapters/enexis_heerlen.py
+++ b/oeds/crawler/netzentgelte/adapters/enexis_heerlen.py
@@ -30,6 +30,7 @@ German cities is therefore only of limited use.
 Verified against: enexis.nl, tariff sheet "Elektriciteit | Kleinverbruik",
 Netbeheerkosten 1 januari 2026, Versie 1.0.
 """
+
 from __future__ import annotations
 
 import re
@@ -40,7 +41,9 @@ from . import _common as c
 NETZBETREIBER = "Enexis Netbeheer B.V."
 
 
-def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
+def parse(
+    text: str, stadt: str, jahr: int, quelle_url: str
+) -> list[NetzentgeltEintrag]:
     out: list[NetzentgeltEintrag] = []
     m = re.search(r"Versie\s+([\d.]+)", text)
     stand = f"Versie {m.group(1)}" if m else None
@@ -48,20 +51,32 @@ def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[Netzentgelt
     # Table "Aansluiting met elektriciteitsmeter": per connection size
     # Per dag / Per maand / Per jaar (incl. btw). We use the standard household
     # connection 3 x 25 A and take the annual amount (last number).
-    sec = c.slice_between(text, "Aansluiting met elektriciteitsmeter", "Aansluiting zonder")
+    sec = c.slice_between(
+        text, "Aansluiting met elektriciteitsmeter", "Aansluiting zonder"
+    )
     for line in sec.splitlines():
         if re.search(r"3\s*[\u00d7x]\s*25", line):  # "3 x 25" or "3 × 25"
             nums = c.decimals(line)
             if nums:
-                out.append(NetzentgeltEintrag(
-                    stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
-                    netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
-                    benutzungsdauer_klasse=None,
-                    grundpreis_eur_jahr=nums[-1], arbeitspreis_ct_kwh=None,
-                    leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
-                    jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
-                    netto_oder_brutto="brutto", mwst_prozent=21.0,
-                ))
+                out.append(
+                    NetzentgeltEintrag(
+                        stadt=stadt,
+                        netzbetreiber=NETZBETREIBER,
+                        netzbetreiber_typ="Verteilnetz",
+                        netzebene="Niederspannung",
+                        tarifsystem="Grundpreis_Arbeitspreis",
+                        benutzungsdauer_klasse=None,
+                        grundpreis_eur_jahr=nums[-1],
+                        arbeitspreis_ct_kwh=None,
+                        leistungspreis_eur_kw_jahr=None,
+                        leistungspreis_eur_kw_monat=None,
+                        jahr=jahr,
+                        stand_dokument=stand,
+                        quelle_url=quelle_url,
+                        netto_oder_brutto="brutto",
+                        mwst_prozent=21.0,
+                    )
+                )
             break
 
     return out

--- a/oeds/crawler/netzentgelte/adapters/leitungspartner.py
+++ b/oeds/crawler/netzentgelte/adapters/leitungspartner.py
@@ -26,7 +26,6 @@ Columns:
 Verified against: leitungspartner.de, "Preisblatt Netzentgelte Strom", valid from
 01.01.2026.
 """
-
 from __future__ import annotations
 
 import re
@@ -44,28 +43,18 @@ JLP_EBENEN = [
 ]
 
 
-def parse(
-    text: str, stadt: str, jahr: int, quelle_url: str
-) -> list[NetzentgeltEintrag]:
+def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
     out: list[NetzentgeltEintrag] = []
     m = re.search(r"[Gg]ültig ab:?\s*(\d{1,2}\.\d{1,2}\.\d{4})", text)
     stand = m.group(1) if m else None
 
     def add(**kw):
         base = dict(
-            stadt=stadt,
-            netzbetreiber=NETZBETREIBER,
-            netzbetreiber_typ="Verteilnetz",
-            netzebene=None,
-            tarifsystem=None,
-            benutzungsdauer_klasse=None,
-            grundpreis_eur_jahr=None,
-            arbeitspreis_ct_kwh=None,
-            leistungspreis_eur_kw_jahr=None,
-            leistungspreis_eur_kw_monat=None,
-            jahr=jahr,
-            stand_dokument=stand,
-            quelle_url=quelle_url,
+            stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
+            netzebene=None, tarifsystem=None, benutzungsdauer_klasse=None,
+            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=None,
+            leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
+            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
         )
         base.update(kw)
         out.append(NetzentgeltEintrag(**base))
@@ -78,20 +67,12 @@ def parse(
     )
     for ebene, r in zip(JLP_EBENEN, c.numeric_rows(jlp, len(JLP_EBENEN))):
         lp_klein, ap_klein, lp_gross, ap_gross = r[:4]
-        add(
-            netzebene=ebene,
-            tarifsystem="Jahresleistungspreis",
+        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
             benutzungsdauer_klasse="<2500h",
-            leistungspreis_eur_kw_jahr=lp_klein,
-            arbeitspreis_ct_kwh=ap_klein,
-        )
-        add(
-            netzebene=ebene,
-            tarifsystem="Jahresleistungspreis",
+            leistungspreis_eur_kw_jahr=lp_klein, arbeitspreis_ct_kwh=ap_klein)
+        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
             benutzungsdauer_klasse=">=2500h",
-            leistungspreis_eur_kw_jahr=lp_gross,
-            arbeitspreis_ct_kwh=ap_gross,
-        )
+            leistungspreis_eur_kw_jahr=lp_gross, arbeitspreis_ct_kwh=ap_gross)
 
     # Household tariff low voltage (price sheet 3):
     # "Niederspannungsnetz 76,65 91,21 7,23 8,60" -> base price net/gross, energy price net/gross
@@ -100,12 +81,8 @@ def parse(
         if line.strip().startswith("Niederspannung"):
             nums = c.decimals(line)
             if len(nums) >= 4:
-                add(
-                    netzebene="Niederspannung",
-                    tarifsystem="Grundpreis_Arbeitspreis",
-                    grundpreis_eur_jahr=nums[0],
-                    arbeitspreis_ct_kwh=nums[2],
-                )
+                add(netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
+                    grundpreis_eur_jahr=nums[0], arbeitspreis_ct_kwh=nums[2])
                 break
 
     return out

--- a/oeds/crawler/netzentgelte/adapters/leitungspartner.py
+++ b/oeds/crawler/netzentgelte/adapters/leitungspartner.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Christoph Komanns
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Adapter for Leitungspartner GmbH - distribution system operator for Düren and
+Merzenich (subsidiary of Stadtwerke Düren GmbH).
+
+NOTE on city->VNB mapping: the grid operator in Düren is NOT Stadtwerke Düren
+GmbH (that is the supplier/default provider), but Leitungspartner GmbH.
+
+Layout: numbered "Preisblätter". pdfplumber wraps some two-line labels in the
+annual capacity price system ("... einschl. Umspannung") such that the numbers
+are on their own line. Data rows are therefore mapped to voltage levels by
+their order (not by the label).
+
+Voltage level order in the annual capacity price system (price sheet 1):
+    Hochspannungsnetz einschl. Umspannung  -> Hochspannung
+    Mittelspannungsnetz                    -> Mittelspannung
+    Mittelspannungsnetz einschl. Umspannung-> Umspannung MS/NS
+    Niederspannungsnetz                    -> Niederspannung
+
+Columns:
+    Capacity price[<2500h]  Energy price[<2500h]  Capacity price[>=2500h]  Energy price[>=2500h]
+
+Verified against: leitungspartner.de, "Preisblatt Netzentgelte Strom", valid from
+01.01.2026.
+"""
+from __future__ import annotations
+
+import re
+
+from ..schema import NetzentgeltEintrag
+from . import _common as c
+
+NETZBETREIBER = "Leitungspartner GmbH"
+
+JLP_EBENEN = [
+    "Hochspannung",
+    "Mittelspannung",
+    "Umspannung_MS_NS",
+    "Niederspannung",
+]
+
+
+def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
+    out: list[NetzentgeltEintrag] = []
+    m = re.search(r"[Gg]ültig ab:?\s*(\d{1,2}\.\d{1,2}\.\d{4})", text)
+    stand = m.group(1) if m else None
+
+    def add(**kw):
+        base = dict(
+            stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
+            netzebene=None, tarifsystem=None, benutzungsdauer_klasse=None,
+            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=None,
+            leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
+            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+        )
+        base.update(kw)
+        out.append(NetzentgeltEintrag(**base))
+
+    # Annual capacity price system (price sheet 1)
+    jlp = c.slice_between(
+        text,
+        "Jahresleistungspreissystem für Entnahme mit registrierender Leistungsmessung",
+        "Entgelte für den Messstellenbetrieb",
+    )
+    for ebene, r in zip(JLP_EBENEN, c.numeric_rows(jlp, len(JLP_EBENEN))):
+        lp_klein, ap_klein, lp_gross, ap_gross = r[:4]
+        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
+            benutzungsdauer_klasse="<2500h",
+            leistungspreis_eur_kw_jahr=lp_klein, arbeitspreis_ct_kwh=ap_klein)
+        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
+            benutzungsdauer_klasse=">=2500h",
+            leistungspreis_eur_kw_jahr=lp_gross, arbeitspreis_ct_kwh=ap_gross)
+
+    # Household tariff low voltage (price sheet 3):
+    # "Niederspannungsnetz 76,65 91,21 7,23 8,60" -> base price net/gross, energy price net/gross
+    hh = c.slice_between(text, "Haushaltsbedarf")
+    for line in hh.splitlines():
+        if line.strip().startswith("Niederspannung"):
+            nums = c.decimals(line)
+            if len(nums) >= 4:
+                add(netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
+                    grundpreis_eur_jahr=nums[0], arbeitspreis_ct_kwh=nums[2])
+                break
+
+    return out

--- a/oeds/crawler/netzentgelte/adapters/leitungspartner.py
+++ b/oeds/crawler/netzentgelte/adapters/leitungspartner.py
@@ -26,6 +26,7 @@ Columns:
 Verified against: leitungspartner.de, "Preisblatt Netzentgelte Strom", valid from
 01.01.2026.
 """
+
 from __future__ import annotations
 
 import re
@@ -43,18 +44,28 @@ JLP_EBENEN = [
 ]
 
 
-def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
+def parse(
+    text: str, stadt: str, jahr: int, quelle_url: str
+) -> list[NetzentgeltEintrag]:
     out: list[NetzentgeltEintrag] = []
     m = re.search(r"[Gg]ültig ab:?\s*(\d{1,2}\.\d{1,2}\.\d{4})", text)
     stand = m.group(1) if m else None
 
     def add(**kw):
         base = dict(
-            stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
-            netzebene=None, tarifsystem=None, benutzungsdauer_klasse=None,
-            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=None,
-            leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
-            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+            stadt=stadt,
+            netzbetreiber=NETZBETREIBER,
+            netzbetreiber_typ="Verteilnetz",
+            netzebene=None,
+            tarifsystem=None,
+            benutzungsdauer_klasse=None,
+            grundpreis_eur_jahr=None,
+            arbeitspreis_ct_kwh=None,
+            leistungspreis_eur_kw_jahr=None,
+            leistungspreis_eur_kw_monat=None,
+            jahr=jahr,
+            stand_dokument=stand,
+            quelle_url=quelle_url,
         )
         base.update(kw)
         out.append(NetzentgeltEintrag(**base))
@@ -67,12 +78,20 @@ def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[Netzentgelt
     )
     for ebene, r in zip(JLP_EBENEN, c.numeric_rows(jlp, len(JLP_EBENEN))):
         lp_klein, ap_klein, lp_gross, ap_gross = r[:4]
-        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
+        add(
+            netzebene=ebene,
+            tarifsystem="Jahresleistungspreis",
             benutzungsdauer_klasse="<2500h",
-            leistungspreis_eur_kw_jahr=lp_klein, arbeitspreis_ct_kwh=ap_klein)
-        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
+            leistungspreis_eur_kw_jahr=lp_klein,
+            arbeitspreis_ct_kwh=ap_klein,
+        )
+        add(
+            netzebene=ebene,
+            tarifsystem="Jahresleistungspreis",
             benutzungsdauer_klasse=">=2500h",
-            leistungspreis_eur_kw_jahr=lp_gross, arbeitspreis_ct_kwh=ap_gross)
+            leistungspreis_eur_kw_jahr=lp_gross,
+            arbeitspreis_ct_kwh=ap_gross,
+        )
 
     # Household tariff low voltage (price sheet 3):
     # "Niederspannungsnetz 76,65 91,21 7,23 8,60" -> base price net/gross, energy price net/gross
@@ -81,8 +100,12 @@ def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[Netzentgelt
         if line.strip().startswith("Niederspannung"):
             nums = c.decimals(line)
             if len(nums) >= 4:
-                add(netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
-                    grundpreis_eur_jahr=nums[0], arbeitspreis_ct_kwh=nums[2])
+                add(
+                    netzebene="Niederspannung",
+                    tarifsystem="Grundpreis_Arbeitspreis",
+                    grundpreis_eur_jahr=nums[0],
+                    arbeitspreis_ct_kwh=nums[2],
+                )
                 break
 
     return out

--- a/oeds/crawler/netzentgelte/adapters/regionetz.py
+++ b/oeds/crawler/netzentgelte/adapters/regionetz.py
@@ -17,6 +17,7 @@ Columns in the annual capacity price system:
 Verified against: regionetz.de, "Preisblätter Strom Regionetz 2026", valid from
 01.01.2026.
 """
+
 from __future__ import annotations
 
 import re
@@ -37,18 +38,28 @@ JLP_EBENEN = [
 ]
 
 
-def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
+def parse(
+    text: str, stadt: str, jahr: int, quelle_url: str
+) -> list[NetzentgeltEintrag]:
     out: list[NetzentgeltEintrag] = []
     m = re.search(r"[Gg]ültig ab:?\s*(\d{1,2}\.\d{1,2}\.\d{4})", text)
     stand = m.group(1) if m else None
 
     def add(**kw):
         base = dict(
-            stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
-            netzebene=None, tarifsystem=None, benutzungsdauer_klasse=None,
-            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=None,
-            leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
-            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+            stadt=stadt,
+            netzbetreiber=NETZBETREIBER,
+            netzbetreiber_typ="Verteilnetz",
+            netzebene=None,
+            tarifsystem=None,
+            benutzungsdauer_klasse=None,
+            grundpreis_eur_jahr=None,
+            arbeitspreis_ct_kwh=None,
+            leistungspreis_eur_kw_jahr=None,
+            leistungspreis_eur_kw_monat=None,
+            jahr=jahr,
+            stand_dokument=stand,
+            quelle_url=quelle_url,
         )
         base.update(kw)
         out.append(NetzentgeltEintrag(**base))
@@ -61,12 +72,20 @@ def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[Netzentgelt
     )
     for ebene, r in zip(JLP_EBENEN, c.numeric_rows(jlp, len(JLP_EBENEN))):
         lp_klein, ap_klein, lp_gross, ap_gross = r[:4]
-        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
+        add(
+            netzebene=ebene,
+            tarifsystem="Jahresleistungspreis",
             benutzungsdauer_klasse="<2500h",
-            leistungspreis_eur_kw_jahr=lp_klein, arbeitspreis_ct_kwh=ap_klein)
-        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
+            leistungspreis_eur_kw_jahr=lp_klein,
+            arbeitspreis_ct_kwh=ap_klein,
+        )
+        add(
+            netzebene=ebene,
+            tarifsystem="Jahresleistungspreis",
             benutzungsdauer_klasse=">=2500h",
-            leistungspreis_eur_kw_jahr=lp_gross, arbeitspreis_ct_kwh=ap_gross)
+            leistungspreis_eur_kw_jahr=lp_gross,
+            arbeitspreis_ct_kwh=ap_gross,
+        )
 
     # Household tariff low voltage (price sheet 4):
     # "Niederspannung 41,65 49,56 9,32 11,09" -> base price net/gross, energy price net/gross
@@ -75,8 +94,12 @@ def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[Netzentgelt
         if line.strip().startswith("Niederspannung"):
             nums = c.decimals(line)
             if len(nums) >= 4:
-                add(netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
-                    grundpreis_eur_jahr=nums[0], arbeitspreis_ct_kwh=nums[2])
+                add(
+                    netzebene="Niederspannung",
+                    tarifsystem="Grundpreis_Arbeitspreis",
+                    grundpreis_eur_jahr=nums[0],
+                    arbeitspreis_ct_kwh=nums[2],
+                )
                 break
 
     return out

--- a/oeds/crawler/netzentgelte/adapters/regionetz.py
+++ b/oeds/crawler/netzentgelte/adapters/regionetz.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Christoph Komanns
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Adapter for Regionetz GmbH - distribution system operator for Aachen and the
+StädteRegion Aachen (joint venture of STAWAG and EWV).
+
+Layout: numbered "Preisblätter", label always BEFORE the numbers.
+Relevant:
+- Price sheet 1: annual capacity price system per grid/transformation level.
+- Price sheet 4: household customers without interval metering (low voltage).
+
+Columns in the annual capacity price system:
+    Capacity price[<2500h]  Energy price[<2500h]  Capacity price[>=2500h]  Energy price[>=2500h]
+
+Verified against: regionetz.de, "Preisblätter Strom Regionetz 2026", valid from
+01.01.2026.
+"""
+from __future__ import annotations
+
+import re
+
+from ..schema import NetzentgeltEintrag
+from . import _common as c
+
+NETZBETREIBER = "Regionetz GmbH"
+
+# Order of voltage level rows in the annual capacity price system (price sheet 1):
+# High voltage (HS) / HS/MS transformation / Medium voltage (MS) / MS/NS transformation / Low voltage (NS)
+JLP_EBENEN = [
+    "Hochspannung",
+    "Umspannung_HS_MS",
+    "Mittelspannung",
+    "Umspannung_MS_NS",
+    "Niederspannung",
+]
+
+
+def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
+    out: list[NetzentgeltEintrag] = []
+    m = re.search(r"[Gg]ültig ab:?\s*(\d{1,2}\.\d{1,2}\.\d{4})", text)
+    stand = m.group(1) if m else None
+
+    def add(**kw):
+        base = dict(
+            stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
+            netzebene=None, tarifsystem=None, benutzungsdauer_klasse=None,
+            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=None,
+            leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
+            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+        )
+        base.update(kw)
+        out.append(NetzentgeltEintrag(**base))
+
+    # Annual capacity price system (price sheet 1)
+    jlp = c.slice_between(
+        text,
+        "Jahresleistungspreissystem für Entnahme mit registrierender Lastgangmessung",
+        "Monatsleistungspreissystem",
+    )
+    for ebene, r in zip(JLP_EBENEN, c.numeric_rows(jlp, len(JLP_EBENEN))):
+        lp_klein, ap_klein, lp_gross, ap_gross = r[:4]
+        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
+            benutzungsdauer_klasse="<2500h",
+            leistungspreis_eur_kw_jahr=lp_klein, arbeitspreis_ct_kwh=ap_klein)
+        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
+            benutzungsdauer_klasse=">=2500h",
+            leistungspreis_eur_kw_jahr=lp_gross, arbeitspreis_ct_kwh=ap_gross)
+
+    # Household tariff low voltage (price sheet 4):
+    # "Niederspannung 41,65 49,56 9,32 11,09" -> base price net/gross, energy price net/gross
+    hh = c.slice_between(text, "Haushaltsbedarf")
+    for line in hh.splitlines():
+        if line.strip().startswith("Niederspannung"):
+            nums = c.decimals(line)
+            if len(nums) >= 4:
+                add(netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
+                    grundpreis_eur_jahr=nums[0], arbeitspreis_ct_kwh=nums[2])
+                break
+
+    return out

--- a/oeds/crawler/netzentgelte/adapters/regionetz.py
+++ b/oeds/crawler/netzentgelte/adapters/regionetz.py
@@ -17,7 +17,6 @@ Columns in the annual capacity price system:
 Verified against: regionetz.de, "Preisblätter Strom Regionetz 2026", valid from
 01.01.2026.
 """
-
 from __future__ import annotations
 
 import re
@@ -38,28 +37,18 @@ JLP_EBENEN = [
 ]
 
 
-def parse(
-    text: str, stadt: str, jahr: int, quelle_url: str
-) -> list[NetzentgeltEintrag]:
+def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
     out: list[NetzentgeltEintrag] = []
     m = re.search(r"[Gg]ültig ab:?\s*(\d{1,2}\.\d{1,2}\.\d{4})", text)
     stand = m.group(1) if m else None
 
     def add(**kw):
         base = dict(
-            stadt=stadt,
-            netzbetreiber=NETZBETREIBER,
-            netzbetreiber_typ="Verteilnetz",
-            netzebene=None,
-            tarifsystem=None,
-            benutzungsdauer_klasse=None,
-            grundpreis_eur_jahr=None,
-            arbeitspreis_ct_kwh=None,
-            leistungspreis_eur_kw_jahr=None,
-            leistungspreis_eur_kw_monat=None,
-            jahr=jahr,
-            stand_dokument=stand,
-            quelle_url=quelle_url,
+            stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
+            netzebene=None, tarifsystem=None, benutzungsdauer_klasse=None,
+            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=None,
+            leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
+            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
         )
         base.update(kw)
         out.append(NetzentgeltEintrag(**base))
@@ -72,20 +61,12 @@ def parse(
     )
     for ebene, r in zip(JLP_EBENEN, c.numeric_rows(jlp, len(JLP_EBENEN))):
         lp_klein, ap_klein, lp_gross, ap_gross = r[:4]
-        add(
-            netzebene=ebene,
-            tarifsystem="Jahresleistungspreis",
+        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
             benutzungsdauer_klasse="<2500h",
-            leistungspreis_eur_kw_jahr=lp_klein,
-            arbeitspreis_ct_kwh=ap_klein,
-        )
-        add(
-            netzebene=ebene,
-            tarifsystem="Jahresleistungspreis",
+            leistungspreis_eur_kw_jahr=lp_klein, arbeitspreis_ct_kwh=ap_klein)
+        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
             benutzungsdauer_klasse=">=2500h",
-            leistungspreis_eur_kw_jahr=lp_gross,
-            arbeitspreis_ct_kwh=ap_gross,
-        )
+            leistungspreis_eur_kw_jahr=lp_gross, arbeitspreis_ct_kwh=ap_gross)
 
     # Household tariff low voltage (price sheet 4):
     # "Niederspannung 41,65 49,56 9,32 11,09" -> base price net/gross, energy price net/gross
@@ -94,12 +75,8 @@ def parse(
         if line.strip().startswith("Niederspannung"):
             nums = c.decimals(line)
             if len(nums) >= 4:
-                add(
-                    netzebene="Niederspannung",
-                    tarifsystem="Grundpreis_Arbeitspreis",
-                    grundpreis_eur_jahr=nums[0],
-                    arbeitspreis_ct_kwh=nums[2],
-                )
+                add(netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
+                    grundpreis_eur_jahr=nums[0], arbeitspreis_ct_kwh=nums[2])
                 break
 
     return out

--- a/oeds/crawler/netzentgelte/adapters/resa_luettich.py
+++ b/oeds/crawler/netzentgelte/adapters/resa_luettich.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Christoph Komanns
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Adapter for RESA SA - distribution system operator for Liège (BE, Wallonia).
+
+IMPORTANT CONTEXT (please read): Liège is in Belgium (Wallonia). Walloon
+distribution grid fees are set by the regulator CWaPE (tariff period 2026-2029)
+and follow a completely different logic from Germany:
+
+- There is a "terme fixe" (fixed annual amount, €/an) and a "terme
+  proportionnel" (energy price, c€/kWh), the latter depending on meter type
+  (simple/24h, bihoraire off-peak/peak hours, Impact ECO/MEDIUM/PIC tariff).
+- NO household fees tiered by voltage level.
+- Published amounts are TVAC, i.e. INCLUDING 6% Belgian VAT (for households),
+  not net.
+
+This adapter maps the standard household case (simple/24h meter):
+- netzebene = Niederspannung, tarifsystem = Grundpreis_Arbeitspreis
+- grundpreis_eur_jahr = terme fixe (€/an, TVAC)
+- arbeitspreis_ct_kwh = terme proportionnel "simple" (c€/kWh, TVAC)
+- netto_oder_brutto = "brutto"
+
+The Belgian "terme proportionnel" bundles more than the German distribution
+grid fee; a direct numerical comparison with German cities is therefore only
+of limited use.
+
+The source is the official CWaPE synthesis of all Walloon VNBs; this adapter
+reads the row of operator RESA specifically.
+
+Verified against: cwape.be, "Synthèse des tarifs de distribution élec 2026 (FR)",
+valid 01.01.2026-31.12.2026.
+"""
+from __future__ import annotations
+
+import re
+
+from ..schema import NetzentgeltEintrag
+from . import _common as c
+
+NETZBETREIBER = "RESA SA"
+
+
+def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
+    out: list[NetzentgeltEintrag] = []
+    m = re.search(r"Mise à jour du\s+([\d.]+)", text)
+    stand = m.group(1) if m else None
+
+    # Synthesis table row starting with "RESA "
+    # (not "RÉSEAU DES ÉNERGIES DE WAVRE"):
+    #   RESA  <terme fixe €/an>  <simple c€/kWh>  <bihoraire HC>  <bihoraire HP> ...
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("RESA ") and not s.startswith("RÉSEAU"):
+            nums = c.decimals(line)
+            if len(nums) >= 2:
+                out.append(NetzentgeltEintrag(
+                    stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
+                    netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
+                    benutzungsdauer_klasse=None,
+                    grundpreis_eur_jahr=nums[0], arbeitspreis_ct_kwh=nums[1],
+                    leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
+                    jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+                    netto_oder_brutto="brutto", mwst_prozent=6.0,
+                ))
+            break
+
+    return out

--- a/oeds/crawler/netzentgelte/adapters/resa_luettich.py
+++ b/oeds/crawler/netzentgelte/adapters/resa_luettich.py
@@ -32,7 +32,6 @@ reads the row of operator RESA specifically.
 Verified against: cwape.be, "Synthèse des tarifs de distribution élec 2026 (FR)",
 valid 01.01.2026-31.12.2026.
 """
-
 from __future__ import annotations
 
 import re
@@ -43,9 +42,7 @@ from . import _common as c
 NETZBETREIBER = "RESA SA"
 
 
-def parse(
-    text: str, stadt: str, jahr: int, quelle_url: str
-) -> list[NetzentgeltEintrag]:
+def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
     out: list[NetzentgeltEintrag] = []
     m = re.search(r"Mise à jour du\s+([\d.]+)", text)
     stand = m.group(1) if m else None
@@ -58,25 +55,15 @@ def parse(
         if s.startswith("RESA ") and not s.startswith("RÉSEAU"):
             nums = c.decimals(line)
             if len(nums) >= 2:
-                out.append(
-                    NetzentgeltEintrag(
-                        stadt=stadt,
-                        netzbetreiber=NETZBETREIBER,
-                        netzbetreiber_typ="Verteilnetz",
-                        netzebene="Niederspannung",
-                        tarifsystem="Grundpreis_Arbeitspreis",
-                        benutzungsdauer_klasse=None,
-                        grundpreis_eur_jahr=nums[0],
-                        arbeitspreis_ct_kwh=nums[1],
-                        leistungspreis_eur_kw_jahr=None,
-                        leistungspreis_eur_kw_monat=None,
-                        jahr=jahr,
-                        stand_dokument=stand,
-                        quelle_url=quelle_url,
-                        netto_oder_brutto="brutto",
-                        mwst_prozent=6.0,
-                    )
-                )
+                out.append(NetzentgeltEintrag(
+                    stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
+                    netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
+                    benutzungsdauer_klasse=None,
+                    grundpreis_eur_jahr=nums[0], arbeitspreis_ct_kwh=nums[1],
+                    leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
+                    jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+                    netto_oder_brutto="brutto", mwst_prozent=6.0,
+                ))
             break
 
     return out

--- a/oeds/crawler/netzentgelte/adapters/resa_luettich.py
+++ b/oeds/crawler/netzentgelte/adapters/resa_luettich.py
@@ -32,6 +32,7 @@ reads the row of operator RESA specifically.
 Verified against: cwape.be, "Synthèse des tarifs de distribution élec 2026 (FR)",
 valid 01.01.2026-31.12.2026.
 """
+
 from __future__ import annotations
 
 import re
@@ -42,7 +43,9 @@ from . import _common as c
 NETZBETREIBER = "RESA SA"
 
 
-def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
+def parse(
+    text: str, stadt: str, jahr: int, quelle_url: str
+) -> list[NetzentgeltEintrag]:
     out: list[NetzentgeltEintrag] = []
     m = re.search(r"Mise à jour du\s+([\d.]+)", text)
     stand = m.group(1) if m else None
@@ -55,15 +58,25 @@ def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[Netzentgelt
         if s.startswith("RESA ") and not s.startswith("RÉSEAU"):
             nums = c.decimals(line)
             if len(nums) >= 2:
-                out.append(NetzentgeltEintrag(
-                    stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
-                    netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
-                    benutzungsdauer_klasse=None,
-                    grundpreis_eur_jahr=nums[0], arbeitspreis_ct_kwh=nums[1],
-                    leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
-                    jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
-                    netto_oder_brutto="brutto", mwst_prozent=6.0,
-                ))
+                out.append(
+                    NetzentgeltEintrag(
+                        stadt=stadt,
+                        netzbetreiber=NETZBETREIBER,
+                        netzbetreiber_typ="Verteilnetz",
+                        netzebene="Niederspannung",
+                        tarifsystem="Grundpreis_Arbeitspreis",
+                        benutzungsdauer_klasse=None,
+                        grundpreis_eur_jahr=nums[0],
+                        arbeitspreis_ct_kwh=nums[1],
+                        leistungspreis_eur_kw_jahr=None,
+                        leistungspreis_eur_kw_monat=None,
+                        jahr=jahr,
+                        stand_dokument=stand,
+                        quelle_url=quelle_url,
+                        netto_oder_brutto="brutto",
+                        mwst_prozent=6.0,
+                    )
+                )
             break
 
     return out

--- a/oeds/crawler/netzentgelte/adapters/rheinnetz.py
+++ b/oeds/crawler/netzentgelte/adapters/rheinnetz.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Christoph Komanns
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Adapter for Rheinische NETZGesellschaft mbH (RheinNetz) - distribution system
+operator for Cologne.
+
+RheinNetz does NOT publish its price sheet in EDI code list format (unlike
+Stromnetz Berlin), but as numbered "Preisblätter 1..14". Relevant for this
+tool:
+- Price sheet 1: household customers without interval metering (low voltage,
+  base price + energy price).
+- Price sheet 4: annual (capacity) price system per grid/transformation level
+  (RLM customers).
+
+Columns in the annual price system (price sheet 4):
+    Capacity price[<2500h]  Energy price[<2500h]  Capacity price[>=2500h]  Energy price[>=2500h]
+
+Verified against: rheinnetz.de, "Netznutzungsentgelte Strom 2026", valid from
+01.01.2026 (provisional, as of 10.10.2025).
+"""
+from __future__ import annotations
+
+import re
+
+from ..schema import NetzentgeltEintrag
+from . import _common as c
+
+NETZBETREIBER = "Rheinische NETZGesellschaft mbH (RheinNetz)"
+
+# Order of voltage level rows in the annual price system (price sheet 4).
+JLP_EBENEN = [
+    "Hochspannung",
+    "Umspannung_HS_MS",      # "Hochspannung mit Umspannung auf MS"
+    "Mittelspannung",
+    "Umspannung_MS_NS",      # "Mittelspannung mit Umspannung auf NS"
+    "Niederspannung",
+]
+
+
+def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
+    out: list[NetzentgeltEintrag] = []
+    m = (re.search(r"Stand[:\s]*?(\d{2}\.\d{2}\.\d{4})", text)
+         or re.search(r"[Gg]ültig ab\s*(\d{2}\.\d{2}\.\d{4})", text))
+    stand = m.group(1) if m else None
+
+    def add(**kw):
+        base = dict(
+            stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
+            netzebene=None, tarifsystem=None, benutzungsdauer_klasse=None,
+            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=None,
+            leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
+            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+        )
+        base.update(kw)
+        out.append(NetzentgeltEintrag(**base))
+
+    # Household tariff low voltage (price sheet 1):
+    # "Niederspannung 150,00 178,50 3,78 4,50"  -> base price net/gross, energy price net/gross
+    pb1 = c.slice_between(text, "Preisblatt 1", "Preisblatt 2")
+    for line in pb1.splitlines():
+        if line.strip().startswith("Niederspannung"):
+            nums = c.decimals(line)
+            if len(nums) >= 4:
+                add(netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
+                    grundpreis_eur_jahr=nums[0], arbeitspreis_ct_kwh=nums[2])
+                break
+
+    # Annual capacity price system (price sheet 4)
+    jlp = c.slice_between(text, "Jahrespreissystem", "Monatspreissystem")
+    for ebene, r in zip(JLP_EBENEN, c.numeric_rows(jlp, len(JLP_EBENEN))):
+        lp_klein, ap_klein, lp_gross, ap_gross = r[:4]
+        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
+            benutzungsdauer_klasse="<2500h",
+            leistungspreis_eur_kw_jahr=lp_klein, arbeitspreis_ct_kwh=ap_klein)
+        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
+            benutzungsdauer_klasse=">=2500h",
+            leistungspreis_eur_kw_jahr=lp_gross, arbeitspreis_ct_kwh=ap_gross)
+
+    return out

--- a/oeds/crawler/netzentgelte/adapters/rheinnetz.py
+++ b/oeds/crawler/netzentgelte/adapters/rheinnetz.py
@@ -20,6 +20,7 @@ Columns in the annual price system (price sheet 4):
 Verified against: rheinnetz.de, "Netznutzungsentgelte Strom 2026", valid from
 01.01.2026 (provisional, as of 10.10.2025).
 """
+
 from __future__ import annotations
 
 import re
@@ -32,26 +33,37 @@ NETZBETREIBER = "Rheinische NETZGesellschaft mbH (RheinNetz)"
 # Order of voltage level rows in the annual price system (price sheet 4).
 JLP_EBENEN = [
     "Hochspannung",
-    "Umspannung_HS_MS",      # "Hochspannung mit Umspannung auf MS"
+    "Umspannung_HS_MS",  # "Hochspannung mit Umspannung auf MS"
     "Mittelspannung",
-    "Umspannung_MS_NS",      # "Mittelspannung mit Umspannung auf NS"
+    "Umspannung_MS_NS",  # "Mittelspannung mit Umspannung auf NS"
     "Niederspannung",
 ]
 
 
-def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
+def parse(
+    text: str, stadt: str, jahr: int, quelle_url: str
+) -> list[NetzentgeltEintrag]:
     out: list[NetzentgeltEintrag] = []
-    m = (re.search(r"Stand[:\s]*?(\d{2}\.\d{2}\.\d{4})", text)
-         or re.search(r"[Gg]ültig ab\s*(\d{2}\.\d{2}\.\d{4})", text))
+    m = re.search(r"Stand[:\s]*?(\d{2}\.\d{2}\.\d{4})", text) or re.search(
+        r"[Gg]ültig ab\s*(\d{2}\.\d{2}\.\d{4})", text
+    )
     stand = m.group(1) if m else None
 
     def add(**kw):
         base = dict(
-            stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
-            netzebene=None, tarifsystem=None, benutzungsdauer_klasse=None,
-            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=None,
-            leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
-            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+            stadt=stadt,
+            netzbetreiber=NETZBETREIBER,
+            netzbetreiber_typ="Verteilnetz",
+            netzebene=None,
+            tarifsystem=None,
+            benutzungsdauer_klasse=None,
+            grundpreis_eur_jahr=None,
+            arbeitspreis_ct_kwh=None,
+            leistungspreis_eur_kw_jahr=None,
+            leistungspreis_eur_kw_monat=None,
+            jahr=jahr,
+            stand_dokument=stand,
+            quelle_url=quelle_url,
         )
         base.update(kw)
         out.append(NetzentgeltEintrag(**base))
@@ -63,19 +75,31 @@ def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[Netzentgelt
         if line.strip().startswith("Niederspannung"):
             nums = c.decimals(line)
             if len(nums) >= 4:
-                add(netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
-                    grundpreis_eur_jahr=nums[0], arbeitspreis_ct_kwh=nums[2])
+                add(
+                    netzebene="Niederspannung",
+                    tarifsystem="Grundpreis_Arbeitspreis",
+                    grundpreis_eur_jahr=nums[0],
+                    arbeitspreis_ct_kwh=nums[2],
+                )
                 break
 
     # Annual capacity price system (price sheet 4)
     jlp = c.slice_between(text, "Jahrespreissystem", "Monatspreissystem")
     for ebene, r in zip(JLP_EBENEN, c.numeric_rows(jlp, len(JLP_EBENEN))):
         lp_klein, ap_klein, lp_gross, ap_gross = r[:4]
-        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
+        add(
+            netzebene=ebene,
+            tarifsystem="Jahresleistungspreis",
             benutzungsdauer_klasse="<2500h",
-            leistungspreis_eur_kw_jahr=lp_klein, arbeitspreis_ct_kwh=ap_klein)
-        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
+            leistungspreis_eur_kw_jahr=lp_klein,
+            arbeitspreis_ct_kwh=ap_klein,
+        )
+        add(
+            netzebene=ebene,
+            tarifsystem="Jahresleistungspreis",
             benutzungsdauer_klasse=">=2500h",
-            leistungspreis_eur_kw_jahr=lp_gross, arbeitspreis_ct_kwh=ap_gross)
+            leistungspreis_eur_kw_jahr=lp_gross,
+            arbeitspreis_ct_kwh=ap_gross,
+        )
 
     return out

--- a/oeds/crawler/netzentgelte/adapters/rheinnetz.py
+++ b/oeds/crawler/netzentgelte/adapters/rheinnetz.py
@@ -20,7 +20,6 @@ Columns in the annual price system (price sheet 4):
 Verified against: rheinnetz.de, "Netznutzungsentgelte Strom 2026", valid from
 01.01.2026 (provisional, as of 10.10.2025).
 """
-
 from __future__ import annotations
 
 import re
@@ -33,37 +32,26 @@ NETZBETREIBER = "Rheinische NETZGesellschaft mbH (RheinNetz)"
 # Order of voltage level rows in the annual price system (price sheet 4).
 JLP_EBENEN = [
     "Hochspannung",
-    "Umspannung_HS_MS",  # "Hochspannung mit Umspannung auf MS"
+    "Umspannung_HS_MS",      # "Hochspannung mit Umspannung auf MS"
     "Mittelspannung",
-    "Umspannung_MS_NS",  # "Mittelspannung mit Umspannung auf NS"
+    "Umspannung_MS_NS",      # "Mittelspannung mit Umspannung auf NS"
     "Niederspannung",
 ]
 
 
-def parse(
-    text: str, stadt: str, jahr: int, quelle_url: str
-) -> list[NetzentgeltEintrag]:
+def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
     out: list[NetzentgeltEintrag] = []
-    m = re.search(r"Stand[:\s]*?(\d{2}\.\d{2}\.\d{4})", text) or re.search(
-        r"[Gg]ültig ab\s*(\d{2}\.\d{2}\.\d{4})", text
-    )
+    m = (re.search(r"Stand[:\s]*?(\d{2}\.\d{2}\.\d{4})", text)
+         or re.search(r"[Gg]ültig ab\s*(\d{2}\.\d{2}\.\d{4})", text))
     stand = m.group(1) if m else None
 
     def add(**kw):
         base = dict(
-            stadt=stadt,
-            netzbetreiber=NETZBETREIBER,
-            netzbetreiber_typ="Verteilnetz",
-            netzebene=None,
-            tarifsystem=None,
-            benutzungsdauer_klasse=None,
-            grundpreis_eur_jahr=None,
-            arbeitspreis_ct_kwh=None,
-            leistungspreis_eur_kw_jahr=None,
-            leistungspreis_eur_kw_monat=None,
-            jahr=jahr,
-            stand_dokument=stand,
-            quelle_url=quelle_url,
+            stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
+            netzebene=None, tarifsystem=None, benutzungsdauer_klasse=None,
+            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=None,
+            leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
+            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
         )
         base.update(kw)
         out.append(NetzentgeltEintrag(**base))
@@ -75,31 +63,19 @@ def parse(
         if line.strip().startswith("Niederspannung"):
             nums = c.decimals(line)
             if len(nums) >= 4:
-                add(
-                    netzebene="Niederspannung",
-                    tarifsystem="Grundpreis_Arbeitspreis",
-                    grundpreis_eur_jahr=nums[0],
-                    arbeitspreis_ct_kwh=nums[2],
-                )
+                add(netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
+                    grundpreis_eur_jahr=nums[0], arbeitspreis_ct_kwh=nums[2])
                 break
 
     # Annual capacity price system (price sheet 4)
     jlp = c.slice_between(text, "Jahrespreissystem", "Monatspreissystem")
     for ebene, r in zip(JLP_EBENEN, c.numeric_rows(jlp, len(JLP_EBENEN))):
         lp_klein, ap_klein, lp_gross, ap_gross = r[:4]
-        add(
-            netzebene=ebene,
-            tarifsystem="Jahresleistungspreis",
+        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
             benutzungsdauer_klasse="<2500h",
-            leistungspreis_eur_kw_jahr=lp_klein,
-            arbeitspreis_ct_kwh=ap_klein,
-        )
-        add(
-            netzebene=ebene,
-            tarifsystem="Jahresleistungspreis",
+            leistungspreis_eur_kw_jahr=lp_klein, arbeitspreis_ct_kwh=ap_klein)
+        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
             benutzungsdauer_klasse=">=2500h",
-            leistungspreis_eur_kw_jahr=lp_gross,
-            arbeitspreis_ct_kwh=ap_gross,
-        )
+            leistungspreis_eur_kw_jahr=lp_gross, arbeitspreis_ct_kwh=ap_gross)
 
     return out

--- a/oeds/crawler/netzentgelte/adapters/stadtwerke_juelich.py
+++ b/oeds/crawler/netzentgelte/adapters/stadtwerke_juelich.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Christoph Komanns
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Adapter for Stadtwerke Jülich GmbH - distribution system operator for Jülich.
+
+Layout: numbered sections ("1. Jahresleistungspreissystem ...",
+"3.1. Kunden, die nach Standardlastprofilen abgerechnet werden", ...),
+label always BEFORE the numbers.
+
+Particularity: Jülich is a small municipal grid and has NO high-voltage level in
+the price sheet - it starts at "Umspannung zur Mittelspannung".
+
+Columns in the annual capacity price system:
+    Capacity price[<2500h]  Energy price[<2500h]  Capacity price[>=2500h]  Energy price[>=2500h]
+
+Verified against: netz.stadtwerke-juelich.de, "Netznutzungsentgelte nach StromNEV
+valid from 1.1.2026".
+"""
+from __future__ import annotations
+
+import re
+
+from ..schema import NetzentgeltEintrag
+from . import _common as c
+
+NETZBETREIBER = "Stadtwerke Jülich GmbH"
+
+# Order of voltage level rows in the annual capacity price system (section 1):
+# Transformation to medium voltage / Medium voltage grid / Transformation to low voltage / Low voltage grid
+JLP_EBENEN = [
+    "Umspannung_HS_MS",
+    "Mittelspannung",
+    "Umspannung_MS_NS",
+    "Niederspannung",
+]
+
+
+def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
+    out: list[NetzentgeltEintrag] = []
+    m = re.search(r"[Gg]ültig ab\s*(\d{1,2}\.\d{1,2}\.\d{4})", text)
+    stand = m.group(1) if m else None
+
+    def add(**kw):
+        base = dict(
+            stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
+            netzebene=None, tarifsystem=None, benutzungsdauer_klasse=None,
+            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=None,
+            leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
+            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+        )
+        base.update(kw)
+        out.append(NetzentgeltEintrag(**base))
+
+    # Annual capacity price system (section 1)
+    jlp = c.slice_between(text, "1. Jahresleistungspreissystem", "2. Monatsleistungspreissystem")
+    for ebene, r in zip(JLP_EBENEN, c.numeric_rows(jlp, len(JLP_EBENEN))):
+        lp_klein, ap_klein, lp_gross, ap_gross = r[:4]
+        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
+            benutzungsdauer_klasse="<2500h",
+            leistungspreis_eur_kw_jahr=lp_klein, arbeitspreis_ct_kwh=ap_klein)
+        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
+            benutzungsdauer_klasse=">=2500h",
+            leistungspreis_eur_kw_jahr=lp_gross, arbeitspreis_ct_kwh=ap_gross)
+
+    # Household tariff low voltage (section 3.1, standard load profile):
+    # "Niederspannungsnetz 75,00 89,25 7,18 8,54" -> base price net/gross, energy price net/gross
+    hh = c.slice_between(text, "3.1. Kunden, die nach Standardlastprofilen abgerechnet werden")
+    for line in hh.splitlines():
+        if line.strip().startswith("Niederspannung"):
+            nums = c.decimals(line)
+            if len(nums) >= 4:
+                add(netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
+                    grundpreis_eur_jahr=nums[0], arbeitspreis_ct_kwh=nums[2])
+                break
+
+    return out

--- a/oeds/crawler/netzentgelte/adapters/stadtwerke_juelich.py
+++ b/oeds/crawler/netzentgelte/adapters/stadtwerke_juelich.py
@@ -18,6 +18,7 @@ Columns in the annual capacity price system:
 Verified against: netz.stadtwerke-juelich.de, "Netznutzungsentgelte nach StromNEV
 valid from 1.1.2026".
 """
+
 from __future__ import annotations
 
 import re
@@ -37,42 +38,68 @@ JLP_EBENEN = [
 ]
 
 
-def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
+def parse(
+    text: str, stadt: str, jahr: int, quelle_url: str
+) -> list[NetzentgeltEintrag]:
     out: list[NetzentgeltEintrag] = []
     m = re.search(r"[Gg]ültig ab\s*(\d{1,2}\.\d{1,2}\.\d{4})", text)
     stand = m.group(1) if m else None
 
     def add(**kw):
         base = dict(
-            stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
-            netzebene=None, tarifsystem=None, benutzungsdauer_klasse=None,
-            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=None,
-            leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
-            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+            stadt=stadt,
+            netzbetreiber=NETZBETREIBER,
+            netzbetreiber_typ="Verteilnetz",
+            netzebene=None,
+            tarifsystem=None,
+            benutzungsdauer_klasse=None,
+            grundpreis_eur_jahr=None,
+            arbeitspreis_ct_kwh=None,
+            leistungspreis_eur_kw_jahr=None,
+            leistungspreis_eur_kw_monat=None,
+            jahr=jahr,
+            stand_dokument=stand,
+            quelle_url=quelle_url,
         )
         base.update(kw)
         out.append(NetzentgeltEintrag(**base))
 
     # Annual capacity price system (section 1)
-    jlp = c.slice_between(text, "1. Jahresleistungspreissystem", "2. Monatsleistungspreissystem")
+    jlp = c.slice_between(
+        text, "1. Jahresleistungspreissystem", "2. Monatsleistungspreissystem"
+    )
     for ebene, r in zip(JLP_EBENEN, c.numeric_rows(jlp, len(JLP_EBENEN))):
         lp_klein, ap_klein, lp_gross, ap_gross = r[:4]
-        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
+        add(
+            netzebene=ebene,
+            tarifsystem="Jahresleistungspreis",
             benutzungsdauer_klasse="<2500h",
-            leistungspreis_eur_kw_jahr=lp_klein, arbeitspreis_ct_kwh=ap_klein)
-        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
+            leistungspreis_eur_kw_jahr=lp_klein,
+            arbeitspreis_ct_kwh=ap_klein,
+        )
+        add(
+            netzebene=ebene,
+            tarifsystem="Jahresleistungspreis",
             benutzungsdauer_klasse=">=2500h",
-            leistungspreis_eur_kw_jahr=lp_gross, arbeitspreis_ct_kwh=ap_gross)
+            leistungspreis_eur_kw_jahr=lp_gross,
+            arbeitspreis_ct_kwh=ap_gross,
+        )
 
     # Household tariff low voltage (section 3.1, standard load profile):
     # "Niederspannungsnetz 75,00 89,25 7,18 8,54" -> base price net/gross, energy price net/gross
-    hh = c.slice_between(text, "3.1. Kunden, die nach Standardlastprofilen abgerechnet werden")
+    hh = c.slice_between(
+        text, "3.1. Kunden, die nach Standardlastprofilen abgerechnet werden"
+    )
     for line in hh.splitlines():
         if line.strip().startswith("Niederspannung"):
             nums = c.decimals(line)
             if len(nums) >= 4:
-                add(netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
-                    grundpreis_eur_jahr=nums[0], arbeitspreis_ct_kwh=nums[2])
+                add(
+                    netzebene="Niederspannung",
+                    tarifsystem="Grundpreis_Arbeitspreis",
+                    grundpreis_eur_jahr=nums[0],
+                    arbeitspreis_ct_kwh=nums[2],
+                )
                 break
 
     return out

--- a/oeds/crawler/netzentgelte/adapters/stadtwerke_juelich.py
+++ b/oeds/crawler/netzentgelte/adapters/stadtwerke_juelich.py
@@ -18,7 +18,6 @@ Columns in the annual capacity price system:
 Verified against: netz.stadtwerke-juelich.de, "Netznutzungsentgelte nach StromNEV
 valid from 1.1.2026".
 """
-
 from __future__ import annotations
 
 import re
@@ -38,68 +37,42 @@ JLP_EBENEN = [
 ]
 
 
-def parse(
-    text: str, stadt: str, jahr: int, quelle_url: str
-) -> list[NetzentgeltEintrag]:
+def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
     out: list[NetzentgeltEintrag] = []
     m = re.search(r"[Gg]ültig ab\s*(\d{1,2}\.\d{1,2}\.\d{4})", text)
     stand = m.group(1) if m else None
 
     def add(**kw):
         base = dict(
-            stadt=stadt,
-            netzbetreiber=NETZBETREIBER,
-            netzbetreiber_typ="Verteilnetz",
-            netzebene=None,
-            tarifsystem=None,
-            benutzungsdauer_klasse=None,
-            grundpreis_eur_jahr=None,
-            arbeitspreis_ct_kwh=None,
-            leistungspreis_eur_kw_jahr=None,
-            leistungspreis_eur_kw_monat=None,
-            jahr=jahr,
-            stand_dokument=stand,
-            quelle_url=quelle_url,
+            stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
+            netzebene=None, tarifsystem=None, benutzungsdauer_klasse=None,
+            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=None,
+            leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=None,
+            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
         )
         base.update(kw)
         out.append(NetzentgeltEintrag(**base))
 
     # Annual capacity price system (section 1)
-    jlp = c.slice_between(
-        text, "1. Jahresleistungspreissystem", "2. Monatsleistungspreissystem"
-    )
+    jlp = c.slice_between(text, "1. Jahresleistungspreissystem", "2. Monatsleistungspreissystem")
     for ebene, r in zip(JLP_EBENEN, c.numeric_rows(jlp, len(JLP_EBENEN))):
         lp_klein, ap_klein, lp_gross, ap_gross = r[:4]
-        add(
-            netzebene=ebene,
-            tarifsystem="Jahresleistungspreis",
+        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
             benutzungsdauer_klasse="<2500h",
-            leistungspreis_eur_kw_jahr=lp_klein,
-            arbeitspreis_ct_kwh=ap_klein,
-        )
-        add(
-            netzebene=ebene,
-            tarifsystem="Jahresleistungspreis",
+            leistungspreis_eur_kw_jahr=lp_klein, arbeitspreis_ct_kwh=ap_klein)
+        add(netzebene=ebene, tarifsystem="Jahresleistungspreis",
             benutzungsdauer_klasse=">=2500h",
-            leistungspreis_eur_kw_jahr=lp_gross,
-            arbeitspreis_ct_kwh=ap_gross,
-        )
+            leistungspreis_eur_kw_jahr=lp_gross, arbeitspreis_ct_kwh=ap_gross)
 
     # Household tariff low voltage (section 3.1, standard load profile):
     # "Niederspannungsnetz 75,00 89,25 7,18 8,54" -> base price net/gross, energy price net/gross
-    hh = c.slice_between(
-        text, "3.1. Kunden, die nach Standardlastprofilen abgerechnet werden"
-    )
+    hh = c.slice_between(text, "3.1. Kunden, die nach Standardlastprofilen abgerechnet werden")
     for line in hh.splitlines():
         if line.strip().startswith("Niederspannung"):
             nums = c.decimals(line)
             if len(nums) >= 4:
-                add(
-                    netzebene="Niederspannung",
-                    tarifsystem="Grundpreis_Arbeitspreis",
-                    grundpreis_eur_jahr=nums[0],
-                    arbeitspreis_ct_kwh=nums[2],
-                )
+                add(netzebene="Niederspannung", tarifsystem="Grundpreis_Arbeitspreis",
+                    grundpreis_eur_jahr=nums[0], arbeitspreis_ct_kwh=nums[2])
                 break
 
     return out

--- a/oeds/crawler/netzentgelte/adapters/stromnetz_berlin.py
+++ b/oeds/crawler/netzentgelte/adapters/stromnetz_berlin.py
@@ -17,6 +17,7 @@ README, section "Adding a new grid operator").
 Verified against: stromnetz.berlin, price sheet valid from 01.01.2026,
 version 15.10.2025 (provisional).
 """
+
 from __future__ import annotations
 
 import re
@@ -38,13 +39,17 @@ JLP_LP = re.compile(
     r"Jahresleistungspreissystem (Hochspannung|Mittelspannung|Niederspannung|"
     r"Umspannung Hoch-/Mittelspannung|Umspannung Mittel-/Niederspannung) "
     r"Jahresbenutzungsdauerstunden (< 2\.500 h/a|>= 2\.500 h/a) Leistungspreis "
-    + NUM + r" " + NUM
+    + NUM
+    + r" "
+    + NUM
 )
 JLP_AP = re.compile(
     r"Jahresleistungspreissystem (Hochspannung|Mittelspannung|Niederspannung|"
     r"Umspannung Hoch-/Mittelspannung|Umspannung Mittel-/Niederspannung) "
     r"Jahresbenutzungsdauerstunden (< 2\.500 h/a|>= 2\.500 h/a) Arbeitspreis "
-    + NUM + r" " + NUM
+    + NUM
+    + r" "
+    + NUM
 )
 
 # Base price / energy price system (= household customer tariff, low voltage)
@@ -71,21 +76,39 @@ BENUTZUNGSDAUER_MAP = {
 }
 
 
-def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
+def parse(
+    text: str, stadt: str, jahr: int, quelle_url: str
+) -> list[NetzentgeltEintrag]:
     out: list[NetzentgeltEintrag] = []
 
     stand_match = re.search(r"Version (\d{2}\.\d{2}\.\d{4})", text)
     stand = stand_match.group(1) if stand_match else None
 
-    def make(netzebene, tarifsystem, benutzungsdauer, grundpreis, arbeitspreis, leistungspreis_jahr):
-        out.append(NetzentgeltEintrag(
-            stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
-            netzebene=netzebene, tarifsystem=tarifsystem,
-            benutzungsdauer_klasse=benutzungsdauer,
-            grundpreis_eur_jahr=grundpreis, arbeitspreis_ct_kwh=arbeitspreis,
-            leistungspreis_eur_kw_jahr=leistungspreis_jahr, leistungspreis_eur_kw_monat=None,
-            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
-        ))
+    def make(
+        netzebene,
+        tarifsystem,
+        benutzungsdauer,
+        grundpreis,
+        arbeitspreis,
+        leistungspreis_jahr,
+    ):
+        out.append(
+            NetzentgeltEintrag(
+                stadt=stadt,
+                netzbetreiber=NETZBETREIBER,
+                netzbetreiber_typ="Verteilnetz",
+                netzebene=netzebene,
+                tarifsystem=tarifsystem,
+                benutzungsdauer_klasse=benutzungsdauer,
+                grundpreis_eur_jahr=grundpreis,
+                arbeitspreis_ct_kwh=arbeitspreis,
+                leistungspreis_eur_kw_jahr=leistungspreis_jahr,
+                leistungspreis_eur_kw_monat=None,
+                jahr=jahr,
+                stand_dokument=stand,
+                quelle_url=quelle_url,
+            )
+        )
 
     # Collect capacity price per voltage level/utilisation hours, then merge with energy price
     lp_values: dict[tuple[str, str], float] = {}
@@ -98,7 +121,9 @@ def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[Netzentgelt
         netzebene = NETZEBENE_MAP[ebene]
         benutzungsdauer = BENUTZUNGSDAUER_MAP[dauer]
         lp = lp_values.get((ebene, dauer))
-        make(netzebene, "Jahresleistungspreis", benutzungsdauer, None, _de_float(ap), lp)
+        make(
+            netzebene, "Jahresleistungspreis", benutzungsdauer, None, _de_float(ap), lp
+        )
 
     # Household customer tariff (base price / energy price system, low voltage)
     gp_match = GP.search(text)
@@ -107,7 +132,13 @@ def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[Netzentgelt
     arbeitspreis_haushalt = _de_float(ap_match.group(1)) if ap_match else None
 
     if grundpreis is not None or arbeitspreis_haushalt is not None:
-        make("Niederspannung", "Grundpreis_Arbeitspreis", None,
-             grundpreis, arbeitspreis_haushalt, None)
+        make(
+            "Niederspannung",
+            "Grundpreis_Arbeitspreis",
+            None,
+            grundpreis,
+            arbeitspreis_haushalt,
+            None,
+        )
 
     return out

--- a/oeds/crawler/netzentgelte/adapters/stromnetz_berlin.py
+++ b/oeds/crawler/netzentgelte/adapters/stromnetz_berlin.py
@@ -17,7 +17,6 @@ README, section "Adding a new grid operator").
 Verified against: stromnetz.berlin, price sheet valid from 01.01.2026,
 version 15.10.2025 (provisional).
 """
-
 from __future__ import annotations
 
 import re
@@ -39,17 +38,13 @@ JLP_LP = re.compile(
     r"Jahresleistungspreissystem (Hochspannung|Mittelspannung|Niederspannung|"
     r"Umspannung Hoch-/Mittelspannung|Umspannung Mittel-/Niederspannung) "
     r"Jahresbenutzungsdauerstunden (< 2\.500 h/a|>= 2\.500 h/a) Leistungspreis "
-    + NUM
-    + r" "
-    + NUM
+    + NUM + r" " + NUM
 )
 JLP_AP = re.compile(
     r"Jahresleistungspreissystem (Hochspannung|Mittelspannung|Niederspannung|"
     r"Umspannung Hoch-/Mittelspannung|Umspannung Mittel-/Niederspannung) "
     r"Jahresbenutzungsdauerstunden (< 2\.500 h/a|>= 2\.500 h/a) Arbeitspreis "
-    + NUM
-    + r" "
-    + NUM
+    + NUM + r" " + NUM
 )
 
 # Base price / energy price system (= household customer tariff, low voltage)
@@ -76,39 +71,21 @@ BENUTZUNGSDAUER_MAP = {
 }
 
 
-def parse(
-    text: str, stadt: str, jahr: int, quelle_url: str
-) -> list[NetzentgeltEintrag]:
+def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
     out: list[NetzentgeltEintrag] = []
 
     stand_match = re.search(r"Version (\d{2}\.\d{2}\.\d{4})", text)
     stand = stand_match.group(1) if stand_match else None
 
-    def make(
-        netzebene,
-        tarifsystem,
-        benutzungsdauer,
-        grundpreis,
-        arbeitspreis,
-        leistungspreis_jahr,
-    ):
-        out.append(
-            NetzentgeltEintrag(
-                stadt=stadt,
-                netzbetreiber=NETZBETREIBER,
-                netzbetreiber_typ="Verteilnetz",
-                netzebene=netzebene,
-                tarifsystem=tarifsystem,
-                benutzungsdauer_klasse=benutzungsdauer,
-                grundpreis_eur_jahr=grundpreis,
-                arbeitspreis_ct_kwh=arbeitspreis,
-                leistungspreis_eur_kw_jahr=leistungspreis_jahr,
-                leistungspreis_eur_kw_monat=None,
-                jahr=jahr,
-                stand_dokument=stand,
-                quelle_url=quelle_url,
-            )
-        )
+    def make(netzebene, tarifsystem, benutzungsdauer, grundpreis, arbeitspreis, leistungspreis_jahr):
+        out.append(NetzentgeltEintrag(
+            stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
+            netzebene=netzebene, tarifsystem=tarifsystem,
+            benutzungsdauer_klasse=benutzungsdauer,
+            grundpreis_eur_jahr=grundpreis, arbeitspreis_ct_kwh=arbeitspreis,
+            leistungspreis_eur_kw_jahr=leistungspreis_jahr, leistungspreis_eur_kw_monat=None,
+            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+        ))
 
     # Collect capacity price per voltage level/utilisation hours, then merge with energy price
     lp_values: dict[tuple[str, str], float] = {}
@@ -121,9 +98,7 @@ def parse(
         netzebene = NETZEBENE_MAP[ebene]
         benutzungsdauer = BENUTZUNGSDAUER_MAP[dauer]
         lp = lp_values.get((ebene, dauer))
-        make(
-            netzebene, "Jahresleistungspreis", benutzungsdauer, None, _de_float(ap), lp
-        )
+        make(netzebene, "Jahresleistungspreis", benutzungsdauer, None, _de_float(ap), lp)
 
     # Household customer tariff (base price / energy price system, low voltage)
     gp_match = GP.search(text)
@@ -132,13 +107,7 @@ def parse(
     arbeitspreis_haushalt = _de_float(ap_match.group(1)) if ap_match else None
 
     if grundpreis is not None or arbeitspreis_haushalt is not None:
-        make(
-            "Niederspannung",
-            "Grundpreis_Arbeitspreis",
-            None,
-            grundpreis,
-            arbeitspreis_haushalt,
-            None,
-        )
+        make("Niederspannung", "Grundpreis_Arbeitspreis", None,
+             grundpreis, arbeitspreis_haushalt, None)
 
     return out

--- a/oeds/crawler/netzentgelte/adapters/stromnetz_berlin.py
+++ b/oeds/crawler/netzentgelte/adapters/stromnetz_berlin.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Christoph Komanns
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Adapter for Stromnetz Berlin GmbH (distribution system operator for Berlin).
+
+Stromnetz Berlin (like many German VNBs) publishes its price sheet in EDI code
+list format: each line starts with an ID like "1-01-7-002", followed by a
+label, net price, gross price, unit.
+
+This format is NOT a nationwide standard, but very common because many VNBs
+follow the BDEW market rules format. Other VNBs (e.g. SWM Infrastruktur,
+Bayernwerk Netz) use different layouts - each needs its own thin adapter (see
+README, section "Adding a new grid operator").
+
+Verified against: stromnetz.berlin, price sheet valid from 01.01.2026,
+version 15.10.2025 (provisional).
+"""
+from __future__ import annotations
+
+import re
+
+from ..schema import NetzentgeltEintrag
+
+NETZBETREIBER = "Stromnetz Berlin GmbH"
+
+NUM = r"(-?[\d.]+,\d+)"
+
+
+def _de_float(s: str) -> float:
+    return float(s.replace(".", "").replace(",", "."))
+
+
+# Annual capacity price system rows, e.g.:
+# "1-01-7-001 Jahresleistungspreissystem Niederspannung Jahresbenutzungsdauerstunden < 2.500 h/a Leistungspreis 8,39 9,98 €/kW/a"
+JLP_LP = re.compile(
+    r"Jahresleistungspreissystem (Hochspannung|Mittelspannung|Niederspannung|"
+    r"Umspannung Hoch-/Mittelspannung|Umspannung Mittel-/Niederspannung) "
+    r"Jahresbenutzungsdauerstunden (< 2\.500 h/a|>= 2\.500 h/a) Leistungspreis "
+    + NUM + r" " + NUM
+)
+JLP_AP = re.compile(
+    r"Jahresleistungspreissystem (Hochspannung|Mittelspannung|Niederspannung|"
+    r"Umspannung Hoch-/Mittelspannung|Umspannung Mittel-/Niederspannung) "
+    r"Jahresbenutzungsdauerstunden (< 2\.500 h/a|>= 2\.500 h/a) Arbeitspreis "
+    + NUM + r" " + NUM
+)
+
+# Base price / energy price system (= household customer tariff, low voltage)
+GP = re.compile(
+    r"Grundpreis-/ Arbeitspreissystem Marktlokation Grundpreis für "
+    r"Arbeitspreissystem Grundpreis " + NUM + r" " + NUM
+)
+AP_HAUSHALT = re.compile(
+    r"Arbeitspreis Standardlasttarifzeit \(sonst\. Verbrauch.*?\) "
+    r".*?abgerechnet werden\s+" + NUM + r" " + NUM,
+    re.DOTALL,
+)
+
+NETZEBENE_MAP = {
+    "Hochspannung": "Hochspannung",
+    "Mittelspannung": "Mittelspannung",
+    "Niederspannung": "Niederspannung",
+    "Umspannung Hoch-/Mittelspannung": "Umspannung_HS_MS",
+    "Umspannung Mittel-/Niederspannung": "Umspannung_MS_NS",
+}
+BENUTZUNGSDAUER_MAP = {
+    "< 2.500 h/a": "<2500h",
+    ">= 2.500 h/a": ">=2500h",
+}
+
+
+def parse(text: str, stadt: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
+    out: list[NetzentgeltEintrag] = []
+
+    stand_match = re.search(r"Version (\d{2}\.\d{2}\.\d{4})", text)
+    stand = stand_match.group(1) if stand_match else None
+
+    def make(netzebene, tarifsystem, benutzungsdauer, grundpreis, arbeitspreis, leistungspreis_jahr):
+        out.append(NetzentgeltEintrag(
+            stadt=stadt, netzbetreiber=NETZBETREIBER, netzbetreiber_typ="Verteilnetz",
+            netzebene=netzebene, tarifsystem=tarifsystem,
+            benutzungsdauer_klasse=benutzungsdauer,
+            grundpreis_eur_jahr=grundpreis, arbeitspreis_ct_kwh=arbeitspreis,
+            leistungspreis_eur_kw_jahr=leistungspreis_jahr, leistungspreis_eur_kw_monat=None,
+            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+        ))
+
+    # Collect capacity price per voltage level/utilisation hours, then merge with energy price
+    lp_values: dict[tuple[str, str], float] = {}
+    for m in JLP_LP.finditer(text):
+        ebene, dauer, lp, _ = m.group(1), m.group(2), m.group(3), m.group(4)
+        lp_values[(ebene, dauer)] = _de_float(lp)
+
+    for m in JLP_AP.finditer(text):
+        ebene, dauer, ap, _ = m.group(1), m.group(2), m.group(3), m.group(4)
+        netzebene = NETZEBENE_MAP[ebene]
+        benutzungsdauer = BENUTZUNGSDAUER_MAP[dauer]
+        lp = lp_values.get((ebene, dauer))
+        make(netzebene, "Jahresleistungspreis", benutzungsdauer, None, _de_float(ap), lp)
+
+    # Household customer tariff (base price / energy price system, low voltage)
+    gp_match = GP.search(text)
+    grundpreis = _de_float(gp_match.group(1)) if gp_match else None
+    ap_match = AP_HAUSHALT.search(text)
+    arbeitspreis_haushalt = _de_float(ap_match.group(1)) if ap_match else None
+
+    if grundpreis is not None or arbeitspreis_haushalt is not None:
+        make("Niederspannung", "Grundpreis_Arbeitspreis", None,
+             grundpreis, arbeitspreis_haushalt, None)
+
+    return out

--- a/oeds/crawler/netzentgelte/cities.yaml
+++ b/oeds/crawler/netzentgelte/cities.yaml
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Christoph Komanns
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Configuration: which city is served by which distribution system operator (VNB),
+# and where its current price sheet is located.
+#
+# IMPORTANT: The city -> VNB mapping does not exist anywhere as a reliable,
+# free, machine-readable list (see README, section "Why no 100% automatic
+# solution"). This file must therefore be researched and maintained manually per
+# city - usually a search for "Stadtwerke <city> grid" or "grid operator <city>
+# electricity" is enough.
+#
+# "adapter" points to a module in netzentgelte/adapters/. If no adapter has been
+# written yet for the respective VNB, leave it null - the city is then skipped
+# and emitted as a warning instead of producing wrong data.
+
+cities:
+  - name: "Berlin"
+    vnb: "Stromnetz Berlin GmbH"
+    preisblatt_url: "https://www.stromnetz.berlin/files/globalassets/dokumente/entgelte/zugang/entgelte-01-01-2026/voraussichtliche-nne-b-2026_20251015.pdf"
+    adapter: "stromnetz_berlin"
+
+  # Example of a city WITHOUT a finished adapter (skipped at runtime,
+  # but appears as a console warning so nothing is silently missing):
+  - name: "München"
+    vnb: "SWM Infrastruktur GmbH & Co. KG"
+    preisblatt_url: "https://www.swm-infrastruktur.de/dam/swm-infrastruktur/dokumente/strom/netzzugang-netznutzungsentgelte/preisblaetter-2026/strom-preisblatt-2026.pdf"
+    adapter: null  # TODO: write adapter, see README
+
+  - name: "Wuppertal"
+    vnb: "WSW Netz GmbH"
+    preisblatt_url: "https://www.wsw-netz.de/fileadmin/wsw-netz/Dokumente/durchsuchbar/Stromnetz/Netzzugang/WSW-Netz-S-101_Preisblatt_Strom_2026.pdf"
+    adapter: null  # TODO: write adapter, see README
+
+  # --- Aachen region / Euregio Meuse-Rhine (Germany) ------------------------
+
+  - name: "Jülich"
+    vnb: "Stadtwerke Jülich GmbH"
+    preisblatt_url: "https://netz.stadtwerke-juelich.de/fileadmin/SW-Juelich/user_upload/Netze/NNE_S_2026.pdf"
+    adapter: "stadtwerke_juelich"
+
+  - name: "Aachen"
+    vnb: "Regionetz GmbH"
+    preisblatt_url: "https://www.regionetz.de/de/Service/Downloads/20251212-Preisblaetter-Strom-Regionetz-2026.pdf"
+    adapter: "regionetz"
+
+  - name: "Köln"
+    vnb: "Rheinische NETZGesellschaft mbH (RheinNetz)"
+    preisblatt_url: "https://www.rheinnetz.de/netzentgelte-strom-ab-dem-01.01.2026.pdfx"
+    adapter: "rheinnetz"
+
+  - name: "Düren"
+    # NOTE: grid operator is Leitungspartner GmbH, NOT Stadtwerke Düren GmbH
+    # (that is the supplier/default provider).
+    vnb: "Leitungspartner GmbH"
+    preisblatt_url: "https://www.leitungspartner.de/download/preisblatt-netzentgelte/"
+    adapter: "leitungspartner"
+
+  # --- Abroad: only limited comparability with the German schema --------------
+  # These two cities are not in Germany. Their grid fee systems are structurally
+  # different (see README and adapter docstrings). The nationwide transmission
+  # rows added by the pipeline do NOT apply to them - they only concern German
+  # cities.
+
+  - name: "Heerlen (NL)"
+    vnb: "Enexis Netbeheer B.V."
+    preisblatt_url: "https://www.enexis.nl/-/media/enexis-nl/pdf-documents/tarieven/tarieven-consument/2026/ptkv-elektriciteit--01012026v10.pdf"
+    adapter: "enexis_heerlen"
+
+  - name: "Lüttich (BE)"
+    vnb: "RESA SA"
+    # Official CWaPE synthesis of all Walloon VNBs; the adapter reads the RESA row.
+    preisblatt_url: "https://www.cwape.be/sites/default/files/cwape-documents/SYNTHESE%20DES%20TARIFS%20DE%20DISTRIBUTION%20ELEC%202026%20(FR)-m%C3%A0j%203.02.2026.pdf"
+    adapter: "resa_luettich"

--- a/oeds/crawler/netzentgelte/collect.py
+++ b/oeds/crawler/netzentgelte/collect.py
@@ -20,14 +20,23 @@ tested against saved text excerpts (see tests/).
 
 from __future__ import annotations
 
-import importlib
 import io
 import logging
 from pathlib import Path
 
+import pdfplumber
 import requests
 import yaml
 
+from .adapters import (
+    enexis_heerlen,
+    leitungspartner,
+    regionetz,
+    resa_luettich,
+    rheinnetz,
+    stadtwerke_juelich,
+    stromnetz_berlin,
+)
 from .fetch_uebertragungsnetz import DEFAULT_UENB_PDF_URL, fetch_uenb_entries
 from .schema import NetzentgeltEintrag
 
@@ -37,10 +46,22 @@ log = logging.getLogger("netzentgelte")
 # manually per year or when adding new cities (see file comment there).
 DEFAULT_CITIES_YAML = Path(__file__).parent / "cities.yaml"
 
+# Static mapping from the ``adapter`` name in cities.yaml to its parse function.
+# One small, verified parser per distribution operator - there is deliberately
+# no universal parser (every operator uses its own price sheet layout). New
+# operators are added here together with their adapter module.
+ADAPTERS = {
+    "enexis_heerlen": enexis_heerlen.parse,
+    "leitungspartner": leitungspartner.parse,
+    "regionetz": regionetz.parse,
+    "resa_luettich": resa_luettich.parse,
+    "rheinnetz": rheinnetz.parse,
+    "stadtwerke_juelich": stadtwerke_juelich.parse,
+    "stromnetz_berlin": stromnetz_berlin.parse,
+}
+
 
 def _download_pdf_text(url: str) -> str:
-    import pdfplumber
-
     resp = requests.get(
         url, timeout=30, headers={"User-Agent": "open-energy-data-server/netzentgelte"}
     )
@@ -94,6 +115,15 @@ def collect_entries(
             log.warning(warnings[-1])
             continue
 
+        parse = ADAPTERS.get(adapter_name)
+        if parse is None:
+            warnings.append(
+                f"{name} ({vnb}): unknown adapter '{adapter_name}' - "
+                f"not registered in ADAPTERS."
+            )
+            log.warning(warnings[-1])
+            continue
+
         try:
             text = _download_pdf_text(url)
         except Exception as exc:
@@ -102,10 +132,7 @@ def collect_entries(
             continue
 
         try:
-            mod = importlib.import_module(
-                f".adapters.{adapter_name}", package=__package__
-            )
-            entries = mod.parse(text, stadt=name, jahr=jahr, quelle_url=url)
+            entries = parse(text, stadt=name, jahr=jahr, quelle_url=url)
             all_entries.extend(entries)
             log.info("%s (%s): %d entries", name, vnb, len(entries))
         except Exception as exc:

--- a/oeds/crawler/netzentgelte/collect.py
+++ b/oeds/crawler/netzentgelte/collect.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Christoph Komanns
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Collect grid fee entries for all cities configured in ``cities.yaml`` and add
+the nationwide transmission grid fees (ÜNB).
+
+This is the OEDS crawler variant of the original ``pipeline.run()`` from the
+netzentgelte tool: instead of writing a CSV, ``collect_entries`` returns the
+entries as a list so the crawler can write them to the database. The domain
+logic (which city -> which VNB -> which adapter, plus the nationwide
+transmission part) is unchanged.
+
+IMPORTANT: ``collect_entries`` requires real internet access - the price sheets
+are PDFs on the websites of the individual grid operators or on
+netztransparenz.de. Without network access, only the parsers themselves can be
+tested against saved text excerpts (see tests/).
+"""
+
+from __future__ import annotations
+
+import importlib
+import io
+import logging
+from pathlib import Path
+
+import requests
+import yaml
+
+from .fetch_uebertragungsnetz import DEFAULT_UENB_PDF_URL, fetch_uenb_entries
+from .schema import NetzentgeltEintrag
+
+log = logging.getLogger("netzentgelte")
+
+# Vendored city -> VNB -> price sheet URL -> adapter mapping. Must be maintained
+# manually per year or when adding new cities (see file comment there).
+DEFAULT_CITIES_YAML = Path(__file__).parent / "cities.yaml"
+
+
+def _download_pdf_text(url: str) -> str:
+    import pdfplumber
+
+    resp = requests.get(
+        url, timeout=30, headers={"User-Agent": "open-energy-data-server/netzentgelte"}
+    )
+    resp.raise_for_status()
+    parts = []
+    with pdfplumber.open(io.BytesIO(resp.content)) as pdf:
+        for page in pdf.pages:
+            parts.append(page.extract_text() or "")
+    return "\n".join(parts)
+
+
+def collect_entries(
+    cities_yaml: str | Path = DEFAULT_CITIES_YAML,
+    jahr: int = 2026,
+    uenb_url: str = DEFAULT_UENB_PDF_URL,
+) -> tuple[list[NetzentgeltEintrag], list[str]]:
+    """Fetch and parse all price sheets and return ``(entries, warnings)``.
+
+    Never silently produces wrong or guessed numbers: if a city has no adapter
+    or download/parsing fails, that is recorded as plain text in ``warnings``
+    and the city is simply missing from the result.
+    """
+    with open(cities_yaml, encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    all_entries: list[NetzentgeltEintrag] = []
+    warnings: list[str] = []
+
+    # 1) Transmission grid: once per run, applies nationwide to all German cities.
+    try:
+        uenb_entries = fetch_uenb_entries(jahr=jahr, pdf_url=uenb_url)
+        all_entries.extend(uenb_entries)
+        log.info("Transmission grid (nationwide): %d entries", len(uenb_entries))
+    except Exception as exc:
+        warnings.append(f"Transmission grid could not be loaded: {exc}")
+        log.warning(warnings[-1])
+
+    # 2) Distribution grid: per city, depending on the responsible VNB.
+    for city in config.get("cities", []):
+        name = city["name"]
+        vnb = city["vnb"]
+        url = city["preisblatt_url"]
+        adapter_name = city.get("adapter")
+
+        if not adapter_name:
+            warnings.append(
+                f"{name}: no adapter configured for VNB '{vnb}'. "
+                f"Price sheet URL is on file ({url}), but must be parsed manually "
+                f"or automated via a new adapter."
+            )
+            log.warning(warnings[-1])
+            continue
+
+        try:
+            text = _download_pdf_text(url)
+        except Exception as exc:
+            warnings.append(f"{name} ({vnb}): download failed: {exc}")
+            log.warning(warnings[-1])
+            continue
+
+        try:
+            mod = importlib.import_module(
+                f".adapters.{adapter_name}", package=__package__
+            )
+            entries = mod.parse(text, stadt=name, jahr=jahr, quelle_url=url)
+            all_entries.extend(entries)
+            log.info("%s (%s): %d entries", name, vnb, len(entries))
+        except Exception as exc:
+            warnings.append(f"{name} ({vnb}): parser error: {exc}")
+            log.warning(warnings[-1])
+
+    return all_entries, warnings

--- a/oeds/crawler/netzentgelte/crawler.py
+++ b/oeds/crawler/netzentgelte/crawler.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Christoph Komanns
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+OEDS crawler for German electricity grid fees (Netzentgelte).
+
+Unlike ``eon_grid_fees`` (which obtains grid fees indirectly via the E.ON
+tariff calculator per postal code), this crawler parses the official price
+sheets of distribution system operators (VNB) and the nationwide transmission
+grid price sheet directly and normalises them into a unified schema (one row =
+city x grid operator x voltage level x price component).
+
+The domain logic comes from the ``netzentgelte`` tool and is vendored here as
+the ``oeds.crawler.netzentgelte`` subpackage so that OEDS remains independently
+installable and runnable.
+
+This is structural, annually published data (price sheets apply per calendar
+year), hence a ``DownloadOnceCrawler``. Re-running with ``recreate=True`` or for
+a new ``jahr`` overwrites the table.
+
+IMPORTANT: The crawler requires real internet access. For a new year, update
+the price sheet URLs in ``cities.yaml`` and the transmission grid URL in
+``fetch_uebertragungsnetz.py`` (same maintenance as in the upstream tool).
+"""
+
+import logging
+
+import pandas as pd
+from sqlalchemy import text
+
+from oeds.base_crawler import DEFAULT_CONFIG_LOCATION, DownloadOnceCrawler, load_config
+from oeds.crawler.netzentgelte.collect import DEFAULT_CITIES_YAML, collect_entries
+from oeds.crawler.netzentgelte.fetch_uebertragungsnetz import DEFAULT_UENB_PDF_URL
+from oeds.crawler.netzentgelte.schema import CSV_FIELDS
+
+log = logging.getLogger("netzentgelte")
+log.setLevel(logging.INFO)
+
+#: Validity year of the vendored price sheets (cities.yaml / transmission URL are 2026).
+DEFAULT_JAHR = 2026
+
+TABLE_NAME = "netzentgelte"
+
+metadata_info = {
+    "schema_name": "netzentgelte",
+    "data_date": f"{DEFAULT_JAHR}-01-01",
+    "data_source": (
+        "https://www.netztransparenz.de (transmission grid, nationwide) "
+        "and the price sheets of the respective distribution system operators "
+        "(see cities.yaml)"
+    ),
+    "license": (
+        "Price sheets of the respective grid operators are freely available "
+        "under § 28 StromNEV; redistribution rules vary by operator."
+    ),
+    "description": (
+        "Electricity grid fees per city/distribution operator: household customers "
+        "(SLP, base price/energy price) and higher voltage levels "
+        "(RLM, annual/monthly capacity price), plus nationwide transmission "
+        "grid fees. Net and gross values per price component."
+    ),
+    "contact": "komanns@fh-aachen.de",
+    "temporal_start": f"{DEFAULT_JAHR}-01-01",
+    "temporal_end": f"{DEFAULT_JAHR}-12-31",
+    "concave_hull_geometry": None,
+}
+
+
+class NetzentgeltCrawler(DownloadOnceCrawler):
+    """Downloads electricity grid fees and writes them to the ``netzentgelte``
+    table in the schema of the same name."""
+
+    #: Override before the run via ``crawler.jahr = ...``.
+    jahr: int = DEFAULT_JAHR
+
+    def structure_exists(self) -> bool:
+        try:
+            query = text(f"SELECT 1 FROM {TABLE_NAME} LIMIT 1")
+            with self.engine.connect() as conn:
+                return conn.execute(query).scalar() == 1
+        except Exception:
+            return False
+
+    def crawl_structural(self, recreate: bool = False):
+        if not self.structure_exists() or recreate:
+            log.info("start download netzentgelte (year %s)", self.jahr)
+            entries, warnings = collect_entries(
+                cities_yaml=DEFAULT_CITIES_YAML,
+                jahr=self.jahr,
+                uenb_url=DEFAULT_UENB_PDF_URL,
+            )
+            for warning in warnings:
+                log.warning(warning)
+
+            if not entries:
+                raise RuntimeError(
+                    "No grid fee entries collected - likely no network access. "
+                    "Warnings: " + "; ".join(warnings)
+                )
+
+            df = pd.DataFrame([e.as_dict() for e in entries], columns=CSV_FIELDS)
+            with self.engine.begin() as conn:
+                df.to_sql(TABLE_NAME, conn, if_exists="replace", index=False)
+            log.info(
+                "finished netzentgelte: %d rows written (%d warning(s))",
+                len(df),
+                len(warnings),
+            )
+
+
+if __name__ == "__main__":
+    logging.basicConfig()
+
+    config = load_config(DEFAULT_CONFIG_LOCATION)
+    crawler = NetzentgeltCrawler("netzentgelte", config)
+    crawler.crawl_structural()
+    crawler.set_metadata(metadata_info)

--- a/oeds/crawler/netzentgelte/fetch_uebertragungsnetz.py
+++ b/oeds/crawler/netzentgelte/fetch_uebertragungsnetz.py
@@ -14,10 +14,11 @@ Source: https://www.netztransparenz.de (section "Netzentgelte")
 The PDF is typically republished once per year (provisional around early
 October, final in early December for the following year).
 """
-
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
+from typing import Optional
 
 import requests
 
@@ -69,46 +70,26 @@ def parse_uenb_text(text: str, jahr: int, quelle_url: str) -> list[NetzentgeltEi
             continue
         seen_jlp.add(bezeichnung)
         ap_klein, lp_klein, ap_gross, lp_gross = (
-            _de_float(m.group(2)),
-            _de_float(m.group(3)),
-            _de_float(m.group(4)),
-            _de_float(m.group(5)),
+            _de_float(m.group(2)), _de_float(m.group(3)),
+            _de_float(m.group(4)), _de_float(m.group(5)),
         )
         netzebene = netzebene_map[bezeichnung]
-        out.append(
-            NetzentgeltEintrag(
-                stadt="(bundeseinheitlich)",
-                netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
-                netzbetreiber_typ="Uebertragungsnetz",
-                netzebene=netzebene,
-                tarifsystem="Jahresleistungspreis",
-                benutzungsdauer_klasse="<2500h",
-                grundpreis_eur_jahr=None,
-                arbeitspreis_ct_kwh=ap_klein,
-                leistungspreis_eur_kw_jahr=lp_klein,
-                leistungspreis_eur_kw_monat=None,
-                jahr=jahr,
-                stand_dokument=stand,
-                quelle_url=quelle_url,
-            )
-        )
-        out.append(
-            NetzentgeltEintrag(
-                stadt="(bundeseinheitlich)",
-                netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
-                netzbetreiber_typ="Uebertragungsnetz",
-                netzebene=netzebene,
-                tarifsystem="Jahresleistungspreis",
-                benutzungsdauer_klasse=">=2500h",
-                grundpreis_eur_jahr=None,
-                arbeitspreis_ct_kwh=ap_gross,
-                leistungspreis_eur_kw_jahr=lp_gross,
-                leistungspreis_eur_kw_monat=None,
-                jahr=jahr,
-                stand_dokument=stand,
-                quelle_url=quelle_url,
-            )
-        )
+        out.append(NetzentgeltEintrag(
+            stadt="(bundeseinheitlich)", netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
+            netzbetreiber_typ="Uebertragungsnetz", netzebene=netzebene,
+            tarifsystem="Jahresleistungspreis", benutzungsdauer_klasse="<2500h",
+            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=ap_klein,
+            leistungspreis_eur_kw_jahr=lp_klein, leistungspreis_eur_kw_monat=None,
+            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+        ))
+        out.append(NetzentgeltEintrag(
+            stadt="(bundeseinheitlich)", netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
+            netzbetreiber_typ="Uebertragungsnetz", netzebene=netzebene,
+            tarifsystem="Jahresleistungspreis", benutzungsdauer_klasse=">=2500h",
+            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=ap_gross,
+            leistungspreis_eur_kw_jahr=lp_gross, leistungspreis_eur_kw_monat=None,
+            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+        ))
 
     # Monthly capacity price system row, e.g.: "Höchstspannung (HÖS) 8,84 0,69"
     mlp_pattern = re.compile(
@@ -122,41 +103,29 @@ def parse_uenb_text(text: str, jahr: int, quelle_url: str) -> list[NetzentgeltEi
             continue
         # This regex also matches parts of the JLP row; only accept when
         # NOT followed directly by 4 numbers (otherwise it is the JLP row).
-        tail = text[m.end() : m.end() + 20]
+        tail = text[m.end():m.end() + 20]
         if re.match(r"\s*" + NUM, tail):
             continue
         seen_mlp.add(key)
         lp, ap = _de_float(m.group(2)), _de_float(m.group(3))
         netzebene = netzebene_map[bezeichnung]
-        out.append(
-            NetzentgeltEintrag(
-                stadt="(bundeseinheitlich)",
-                netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
-                netzbetreiber_typ="Uebertragungsnetz",
-                netzebene=netzebene,
-                tarifsystem="Monatsleistungspreis",
-                benutzungsdauer_klasse=None,
-                grundpreis_eur_jahr=None,
-                arbeitspreis_ct_kwh=ap,
-                leistungspreis_eur_kw_jahr=None,
-                leistungspreis_eur_kw_monat=lp,
-                jahr=jahr,
-                stand_dokument=stand,
-                quelle_url=quelle_url,
-            )
-        )
+        out.append(NetzentgeltEintrag(
+            stadt="(bundeseinheitlich)", netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
+            netzbetreiber_typ="Uebertragungsnetz", netzebene=netzebene,
+            tarifsystem="Monatsleistungspreis", benutzungsdauer_klasse=None,
+            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=ap,
+            leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=lp,
+            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+        ))
 
     return out
 
 
-def fetch_uenb_entries(
-    jahr: int, pdf_url: str = DEFAULT_UENB_PDF_URL
-) -> list[NetzentgeltEintrag]:
+def fetch_uenb_entries(jahr: int, pdf_url: str = DEFAULT_UENB_PDF_URL) -> list[NetzentgeltEintrag]:
     """Download the current transmission price sheet and parse it. Requires real
     internet access (does not work in this repo's sandbox, but on a normal
     machine/CI runner with internet access)."""
     import io
-
     import pdfplumber
 
     resp = requests.get(pdf_url, timeout=30)

--- a/oeds/crawler/netzentgelte/fetch_uebertragungsnetz.py
+++ b/oeds/crawler/netzentgelte/fetch_uebertragungsnetz.py
@@ -14,11 +14,10 @@ Source: https://www.netztransparenz.de (section "Netzentgelte")
 The PDF is typically republished once per year (provisional around early
 October, final in early December for the following year).
 """
+
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
-from typing import Optional
 
 import requests
 
@@ -70,26 +69,46 @@ def parse_uenb_text(text: str, jahr: int, quelle_url: str) -> list[NetzentgeltEi
             continue
         seen_jlp.add(bezeichnung)
         ap_klein, lp_klein, ap_gross, lp_gross = (
-            _de_float(m.group(2)), _de_float(m.group(3)),
-            _de_float(m.group(4)), _de_float(m.group(5)),
+            _de_float(m.group(2)),
+            _de_float(m.group(3)),
+            _de_float(m.group(4)),
+            _de_float(m.group(5)),
         )
         netzebene = netzebene_map[bezeichnung]
-        out.append(NetzentgeltEintrag(
-            stadt="(bundeseinheitlich)", netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
-            netzbetreiber_typ="Uebertragungsnetz", netzebene=netzebene,
-            tarifsystem="Jahresleistungspreis", benutzungsdauer_klasse="<2500h",
-            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=ap_klein,
-            leistungspreis_eur_kw_jahr=lp_klein, leistungspreis_eur_kw_monat=None,
-            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
-        ))
-        out.append(NetzentgeltEintrag(
-            stadt="(bundeseinheitlich)", netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
-            netzbetreiber_typ="Uebertragungsnetz", netzebene=netzebene,
-            tarifsystem="Jahresleistungspreis", benutzungsdauer_klasse=">=2500h",
-            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=ap_gross,
-            leistungspreis_eur_kw_jahr=lp_gross, leistungspreis_eur_kw_monat=None,
-            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
-        ))
+        out.append(
+            NetzentgeltEintrag(
+                stadt="(bundeseinheitlich)",
+                netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
+                netzbetreiber_typ="Uebertragungsnetz",
+                netzebene=netzebene,
+                tarifsystem="Jahresleistungspreis",
+                benutzungsdauer_klasse="<2500h",
+                grundpreis_eur_jahr=None,
+                arbeitspreis_ct_kwh=ap_klein,
+                leistungspreis_eur_kw_jahr=lp_klein,
+                leistungspreis_eur_kw_monat=None,
+                jahr=jahr,
+                stand_dokument=stand,
+                quelle_url=quelle_url,
+            )
+        )
+        out.append(
+            NetzentgeltEintrag(
+                stadt="(bundeseinheitlich)",
+                netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
+                netzbetreiber_typ="Uebertragungsnetz",
+                netzebene=netzebene,
+                tarifsystem="Jahresleistungspreis",
+                benutzungsdauer_klasse=">=2500h",
+                grundpreis_eur_jahr=None,
+                arbeitspreis_ct_kwh=ap_gross,
+                leistungspreis_eur_kw_jahr=lp_gross,
+                leistungspreis_eur_kw_monat=None,
+                jahr=jahr,
+                stand_dokument=stand,
+                quelle_url=quelle_url,
+            )
+        )
 
     # Monthly capacity price system row, e.g.: "Höchstspannung (HÖS) 8,84 0,69"
     mlp_pattern = re.compile(
@@ -103,29 +122,41 @@ def parse_uenb_text(text: str, jahr: int, quelle_url: str) -> list[NetzentgeltEi
             continue
         # This regex also matches parts of the JLP row; only accept when
         # NOT followed directly by 4 numbers (otherwise it is the JLP row).
-        tail = text[m.end():m.end() + 20]
+        tail = text[m.end() : m.end() + 20]
         if re.match(r"\s*" + NUM, tail):
             continue
         seen_mlp.add(key)
         lp, ap = _de_float(m.group(2)), _de_float(m.group(3))
         netzebene = netzebene_map[bezeichnung]
-        out.append(NetzentgeltEintrag(
-            stadt="(bundeseinheitlich)", netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
-            netzbetreiber_typ="Uebertragungsnetz", netzebene=netzebene,
-            tarifsystem="Monatsleistungspreis", benutzungsdauer_klasse=None,
-            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=ap,
-            leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=lp,
-            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
-        ))
+        out.append(
+            NetzentgeltEintrag(
+                stadt="(bundeseinheitlich)",
+                netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
+                netzbetreiber_typ="Uebertragungsnetz",
+                netzebene=netzebene,
+                tarifsystem="Monatsleistungspreis",
+                benutzungsdauer_klasse=None,
+                grundpreis_eur_jahr=None,
+                arbeitspreis_ct_kwh=ap,
+                leistungspreis_eur_kw_jahr=None,
+                leistungspreis_eur_kw_monat=lp,
+                jahr=jahr,
+                stand_dokument=stand,
+                quelle_url=quelle_url,
+            )
+        )
 
     return out
 
 
-def fetch_uenb_entries(jahr: int, pdf_url: str = DEFAULT_UENB_PDF_URL) -> list[NetzentgeltEintrag]:
+def fetch_uenb_entries(
+    jahr: int, pdf_url: str = DEFAULT_UENB_PDF_URL
+) -> list[NetzentgeltEintrag]:
     """Download the current transmission price sheet and parse it. Requires real
     internet access (does not work in this repo's sandbox, but on a normal
     machine/CI runner with internet access)."""
     import io
+
     import pdfplumber
 
     resp = requests.get(pdf_url, timeout=30)

--- a/oeds/crawler/netzentgelte/fetch_uebertragungsnetz.py
+++ b/oeds/crawler/netzentgelte/fetch_uebertragungsnetz.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Christoph Komanns
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Transmission grid fees (ÜNB) - nationwide, applies to ALL of Germany.
+
+Since 2023 (NEMoG), the four German transmission system operators (50Hertz,
+Amprion, TenneT, TransnetBW) publish a uniform price sheet for extra-high
+voltage and the HÖS/HS transformation level. This part is fully automatable
+and city-independent: download once per year, parse, done.
+
+Source: https://www.netztransparenz.de (section "Netzentgelte")
+The PDF is typically republished once per year (provisional around early
+October, final in early December for the following year).
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+import requests
+
+from .schema import NetzentgeltEintrag
+
+# This URL changes every year (filename contains the publication date). If in
+# doubt, look up the current link on https://www.netztransparenz.de under
+# "Netzentgelte" -> "Strom" -> "Bundeseinheitliche Netzentgelte" and enter it
+# here, or override NETZTRANSPARENZ_URL at call time.
+DEFAULT_UENB_PDF_URL = (
+    "https://www.netztransparenz.de/xspproxy/api/staticfiles/"
+    "ntp-relaunch/dokumente/netzentgelte/251205_preisblatt_ben_2026.pdf"
+)
+
+NUM = r"([\d.]+,\d+)"
+
+
+def _de_float(s: str) -> float:
+    return float(s.replace(".", "").replace(",", "."))
+
+
+def parse_uenb_text(text: str, jahr: int, quelle_url: str) -> list[NetzentgeltEintrag]:
+    """
+    Parse the full text of the transmission price sheet obtained via
+    pdfplumber/PDF text extraction. Works for the layout used by
+    50Hertz/Amprion/TenneT/TransnetBW since 2023 (verified against 2024-2026 PDFs).
+    """
+    out: list[NetzentgeltEintrag] = []
+
+    stand_match = re.search(r"(\d{2}\.\d{2}\.\d{4})", text)
+    stand = stand_match.group(1) if stand_match else None
+
+    # Annual capacity price system row, e.g.:
+    # "Höchstspannung (HÖS) 11,39 2,36 53,06 0,69"
+    # Source column order: EP(<2500h) CP(<2500h) EP(>=2500h) CP(>=2500h)
+    jlp_pattern = re.compile(
+        r"(Höchstspannung \(HÖS\)|Umspannung \(HÖS/HS\))\s+"
+        rf"{NUM}\s+{NUM}\s+{NUM}\s+{NUM}"
+    )
+    netzebene_map = {
+        "Höchstspannung (HÖS)": "Hoechstspannung",
+        "Umspannung (HÖS/HS)": "Umspannung_HOES_HS",
+    }
+
+    seen_jlp = set()
+    for m in jlp_pattern.finditer(text):
+        bezeichnung = m.group(1)
+        if bezeichnung in seen_jlp:
+            continue
+        seen_jlp.add(bezeichnung)
+        ap_klein, lp_klein, ap_gross, lp_gross = (
+            _de_float(m.group(2)), _de_float(m.group(3)),
+            _de_float(m.group(4)), _de_float(m.group(5)),
+        )
+        netzebene = netzebene_map[bezeichnung]
+        out.append(NetzentgeltEintrag(
+            stadt="(bundeseinheitlich)", netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
+            netzbetreiber_typ="Uebertragungsnetz", netzebene=netzebene,
+            tarifsystem="Jahresleistungspreis", benutzungsdauer_klasse="<2500h",
+            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=ap_klein,
+            leistungspreis_eur_kw_jahr=lp_klein, leistungspreis_eur_kw_monat=None,
+            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+        ))
+        out.append(NetzentgeltEintrag(
+            stadt="(bundeseinheitlich)", netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
+            netzbetreiber_typ="Uebertragungsnetz", netzebene=netzebene,
+            tarifsystem="Jahresleistungspreis", benutzungsdauer_klasse=">=2500h",
+            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=ap_gross,
+            leistungspreis_eur_kw_jahr=lp_gross, leistungspreis_eur_kw_monat=None,
+            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+        ))
+
+    # Monthly capacity price system row, e.g.: "Höchstspannung (HÖS) 8,84 0,69"
+    mlp_pattern = re.compile(
+        r"(Höchstspannung \(HÖS\)|Umspannung \(HÖS/HS\))\s+" + NUM + r"\s+" + NUM
+    )
+    seen_mlp = set()
+    for m in mlp_pattern.finditer(text):
+        bezeichnung = m.group(1)
+        key = (bezeichnung, "mlp")
+        if key in seen_mlp:
+            continue
+        # This regex also matches parts of the JLP row; only accept when
+        # NOT followed directly by 4 numbers (otherwise it is the JLP row).
+        tail = text[m.end():m.end() + 20]
+        if re.match(r"\s*" + NUM, tail):
+            continue
+        seen_mlp.add(key)
+        lp, ap = _de_float(m.group(2)), _de_float(m.group(3))
+        netzebene = netzebene_map[bezeichnung]
+        out.append(NetzentgeltEintrag(
+            stadt="(bundeseinheitlich)", netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
+            netzbetreiber_typ="Uebertragungsnetz", netzebene=netzebene,
+            tarifsystem="Monatsleistungspreis", benutzungsdauer_klasse=None,
+            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=ap,
+            leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=lp,
+            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
+        ))
+
+    return out
+
+
+def fetch_uenb_entries(jahr: int, pdf_url: str = DEFAULT_UENB_PDF_URL) -> list[NetzentgeltEintrag]:
+    """Download the current transmission price sheet and parse it. Requires real
+    internet access (does not work in this repo's sandbox, but on a normal
+    machine/CI runner with internet access)."""
+    import io
+    import pdfplumber
+
+    resp = requests.get(pdf_url, timeout=30)
+    resp.raise_for_status()
+    text_parts = []
+    with pdfplumber.open(io.BytesIO(resp.content)) as pdf:
+        for page in pdf.pages:
+            t = page.extract_text() or ""
+            text_parts.append(t)
+    full_text = "\n".join(text_parts)
+    return parse_uenb_text(full_text, jahr=jahr, quelle_url=pdf_url)

--- a/oeds/crawler/netzentgelte/fetch_uebertragungsnetz.py
+++ b/oeds/crawler/netzentgelte/fetch_uebertragungsnetz.py
@@ -14,6 +14,7 @@ Source: https://www.netztransparenz.de (section "Netzentgelte")
 The PDF is typically republished once per year (provisional around early
 October, final in early December for the following year).
 """
+
 from __future__ import annotations
 
 import io
@@ -70,26 +71,46 @@ def parse_uenb_text(text: str, jahr: int, quelle_url: str) -> list[NetzentgeltEi
             continue
         seen_jlp.add(bezeichnung)
         ap_klein, lp_klein, ap_gross, lp_gross = (
-            _de_float(m.group(2)), _de_float(m.group(3)),
-            _de_float(m.group(4)), _de_float(m.group(5)),
+            _de_float(m.group(2)),
+            _de_float(m.group(3)),
+            _de_float(m.group(4)),
+            _de_float(m.group(5)),
         )
         netzebene = netzebene_map[bezeichnung]
-        out.append(NetzentgeltEintrag(
-            stadt="(bundeseinheitlich)", netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
-            netzbetreiber_typ="Uebertragungsnetz", netzebene=netzebene,
-            tarifsystem="Jahresleistungspreis", benutzungsdauer_klasse="<2500h",
-            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=ap_klein,
-            leistungspreis_eur_kw_jahr=lp_klein, leistungspreis_eur_kw_monat=None,
-            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
-        ))
-        out.append(NetzentgeltEintrag(
-            stadt="(bundeseinheitlich)", netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
-            netzbetreiber_typ="Uebertragungsnetz", netzebene=netzebene,
-            tarifsystem="Jahresleistungspreis", benutzungsdauer_klasse=">=2500h",
-            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=ap_gross,
-            leistungspreis_eur_kw_jahr=lp_gross, leistungspreis_eur_kw_monat=None,
-            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
-        ))
+        out.append(
+            NetzentgeltEintrag(
+                stadt="(bundeseinheitlich)",
+                netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
+                netzbetreiber_typ="Uebertragungsnetz",
+                netzebene=netzebene,
+                tarifsystem="Jahresleistungspreis",
+                benutzungsdauer_klasse="<2500h",
+                grundpreis_eur_jahr=None,
+                arbeitspreis_ct_kwh=ap_klein,
+                leistungspreis_eur_kw_jahr=lp_klein,
+                leistungspreis_eur_kw_monat=None,
+                jahr=jahr,
+                stand_dokument=stand,
+                quelle_url=quelle_url,
+            )
+        )
+        out.append(
+            NetzentgeltEintrag(
+                stadt="(bundeseinheitlich)",
+                netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
+                netzbetreiber_typ="Uebertragungsnetz",
+                netzebene=netzebene,
+                tarifsystem="Jahresleistungspreis",
+                benutzungsdauer_klasse=">=2500h",
+                grundpreis_eur_jahr=None,
+                arbeitspreis_ct_kwh=ap_gross,
+                leistungspreis_eur_kw_jahr=lp_gross,
+                leistungspreis_eur_kw_monat=None,
+                jahr=jahr,
+                stand_dokument=stand,
+                quelle_url=quelle_url,
+            )
+        )
 
     # Monthly capacity price system row, e.g.: "Höchstspannung (HÖS) 8,84 0,69"
     mlp_pattern = re.compile(
@@ -103,25 +124,36 @@ def parse_uenb_text(text: str, jahr: int, quelle_url: str) -> list[NetzentgeltEi
             continue
         # This regex also matches parts of the JLP row; only accept when
         # NOT followed directly by 4 numbers (otherwise it is the JLP row).
-        tail = text[m.end():m.end() + 20]
+        tail = text[m.end() : m.end() + 20]
         if re.match(r"\s*" + NUM, tail):
             continue
         seen_mlp.add(key)
         lp, ap = _de_float(m.group(2)), _de_float(m.group(3))
         netzebene = netzebene_map[bezeichnung]
-        out.append(NetzentgeltEintrag(
-            stadt="(bundeseinheitlich)", netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
-            netzbetreiber_typ="Uebertragungsnetz", netzebene=netzebene,
-            tarifsystem="Monatsleistungspreis", benutzungsdauer_klasse=None,
-            grundpreis_eur_jahr=None, arbeitspreis_ct_kwh=ap,
-            leistungspreis_eur_kw_jahr=None, leistungspreis_eur_kw_monat=lp,
-            jahr=jahr, stand_dokument=stand, quelle_url=quelle_url,
-        ))
+        out.append(
+            NetzentgeltEintrag(
+                stadt="(bundeseinheitlich)",
+                netzbetreiber="ÜNB (50Hertz/Amprion/TenneT/TransnetBW)",
+                netzbetreiber_typ="Uebertragungsnetz",
+                netzebene=netzebene,
+                tarifsystem="Monatsleistungspreis",
+                benutzungsdauer_klasse=None,
+                grundpreis_eur_jahr=None,
+                arbeitspreis_ct_kwh=ap,
+                leistungspreis_eur_kw_jahr=None,
+                leistungspreis_eur_kw_monat=lp,
+                jahr=jahr,
+                stand_dokument=stand,
+                quelle_url=quelle_url,
+            )
+        )
 
     return out
 
 
-def fetch_uenb_entries(jahr: int, pdf_url: str = DEFAULT_UENB_PDF_URL) -> list[NetzentgeltEintrag]:
+def fetch_uenb_entries(
+    jahr: int, pdf_url: str = DEFAULT_UENB_PDF_URL
+) -> list[NetzentgeltEintrag]:
     """Download the current transmission price sheet and parse it. Requires real
     internet access (does not work in this repo's sandbox, but on a normal
     machine/CI runner with internet access)."""

--- a/oeds/crawler/netzentgelte/fetch_uebertragungsnetz.py
+++ b/oeds/crawler/netzentgelte/fetch_uebertragungsnetz.py
@@ -16,10 +16,10 @@ October, final in early December for the following year).
 """
 from __future__ import annotations
 
+import io
 import re
-from dataclasses import dataclass
-from typing import Optional
 
+import pdfplumber
 import requests
 
 from .schema import NetzentgeltEintrag
@@ -125,9 +125,6 @@ def fetch_uenb_entries(jahr: int, pdf_url: str = DEFAULT_UENB_PDF_URL) -> list[N
     """Download the current transmission price sheet and parse it. Requires real
     internet access (does not work in this repo's sandbox, but on a normal
     machine/CI runner with internet access)."""
-    import io
-    import pdfplumber
-
     resp = requests.get(pdf_url, timeout=30)
     resp.raise_for_status()
     text_parts = []

--- a/oeds/crawler/netzentgelte/schema.py
+++ b/oeds/crawler/netzentgelte/schema.py
@@ -19,27 +19,27 @@ Key terminology (see README):
 - The transmission grid (extra-high voltage + HÖS/HS transformation) has been
   nationwide uniform since 2023 and does NOT depend on the individual city/VNB.
 """
+
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
-from typing import Optional
+from dataclasses import asdict, dataclass
 
 # Canonical voltage level names, in order from generation/transmission to the
 # household connection.
 NETZEBENEN = [
-    "Hoechstspannung",            # HÖS - transmission grid
-    "Umspannung_HOES_HS",         # transmission/distribution boundary
-    "Hochspannung",               # HS - distribution grid
-    "Umspannung_HS_MS",           # distribution grid
-    "Mittelspannung",             # MS - distribution grid
-    "Umspannung_MS_NS",           # distribution grid
-    "Niederspannung",             # NS - distribution grid (household connection)
+    "Hoechstspannung",  # HÖS - transmission grid
+    "Umspannung_HOES_HS",  # transmission/distribution boundary
+    "Hochspannung",  # HS - distribution grid
+    "Umspannung_HS_MS",  # distribution grid
+    "Mittelspannung",  # MS - distribution grid
+    "Umspannung_MS_NS",  # distribution grid
+    "Niederspannung",  # NS - distribution grid (household connection)
 ]
 
 TARIFSYSTEME = [
-    "Grundpreis_Arbeitspreis",     # household customers / SLP without interval metering
-    "Jahresleistungspreis",        # RLM customers, annual capacity price system
-    "Monatsleistungspreis",        # RLM customers, monthly capacity price system
+    "Grundpreis_Arbeitspreis",  # household customers / SLP without interval metering
+    "Jahresleistungspreis",  # RLM customers, annual capacity price system
+    "Monatsleistungspreis",  # RLM customers, monthly capacity price system
 ]
 
 # Customer type per tariff system:
@@ -54,7 +54,7 @@ KUNDENTYP_JE_TARIFSYSTEM = {
 }
 
 
-def _brutto(netto: Optional[float], faktor: float) -> Optional[float]:
+def _brutto(netto: float | None, faktor: float) -> float | None:
     """Compute gross value from net value (None stays None)."""
     if netto is None:
         return None
@@ -63,18 +63,18 @@ def _brutto(netto: Optional[float], faktor: float) -> Optional[float]:
 
 @dataclass
 class NetzentgeltEintrag:
-    stadt: str                      # city requested by the user
-    netzbetreiber: str               # name of the grid operator (VNB or ÜNB)
-    netzbetreiber_typ: str           # "Verteilnetz" or "Uebertragungsnetz"
-    netzebene: str                   # one of NETZEBENEN
-    tarifsystem: str                 # one of TARIFSYSTEME
-    benutzungsdauer_klasse: Optional[str]  # "<2500h" / ">=2500h" / None
-    grundpreis_eur_jahr: Optional[float]
-    arbeitspreis_ct_kwh: Optional[float]
-    leistungspreis_eur_kw_jahr: Optional[float]
-    leistungspreis_eur_kw_monat: Optional[float]
-    jahr: int                        # validity year of the price sheet
-    stand_dokument: Optional[str]    # version/effective date per PDF
+    stadt: str  # city requested by the user
+    netzbetreiber: str  # name of the grid operator (VNB or ÜNB)
+    netzbetreiber_typ: str  # "Verteilnetz" or "Uebertragungsnetz"
+    netzebene: str  # one of NETZEBENEN
+    tarifsystem: str  # one of TARIFSYSTEME
+    benutzungsdauer_klasse: str | None  # "<2500h" / ">=2500h" / None
+    grundpreis_eur_jahr: float | None
+    arbeitspreis_ct_kwh: float | None
+    leistungspreis_eur_kw_jahr: float | None
+    leistungspreis_eur_kw_monat: float | None
+    jahr: int  # validity year of the price sheet
+    stand_dokument: str | None  # version/effective date per PDF
     quelle_url: str
     # Basis in which the source publishes the prices above.
     netto_oder_brutto: str = "netto"
@@ -82,38 +82,57 @@ class NetzentgeltEintrag:
     # foreign adapters differ (NL 21, BE 6).
     mwst_prozent: float = 19.0
     # Derived automatically from the tariff system in __post_init__.
-    kundentyp: Optional[str] = None
+    kundentyp: str | None = None
     # Gross counterparts of the price components, computed in __post_init__.
-    grundpreis_eur_jahr_brutto: Optional[float] = None
-    arbeitspreis_ct_kwh_brutto: Optional[float] = None
-    leistungspreis_eur_kw_jahr_brutto: Optional[float] = None
-    leistungspreis_eur_kw_monat_brutto: Optional[float] = None
+    grundpreis_eur_jahr_brutto: float | None = None
+    arbeitspreis_ct_kwh_brutto: float | None = None
+    leistungspreis_eur_kw_jahr_brutto: float | None = None
+    leistungspreis_eur_kw_monat_brutto: float | None = None
 
     def __post_init__(self) -> None:
         if self.kundentyp is None:
             self.kundentyp = KUNDENTYP_JE_TARIFSYSTEM.get(self.tarifsystem)
         # Compute gross values. If the source already publishes gross amounts
         # (e.g. NL/BE), the gross columns match the source values.
-        faktor = 1.0 if self.netto_oder_brutto == "brutto" else 1 + self.mwst_prozent / 100
+        faktor = (
+            1.0 if self.netto_oder_brutto == "brutto" else 1 + self.mwst_prozent / 100
+        )
         if self.grundpreis_eur_jahr_brutto is None:
             self.grundpreis_eur_jahr_brutto = _brutto(self.grundpreis_eur_jahr, faktor)
         if self.arbeitspreis_ct_kwh_brutto is None:
             self.arbeitspreis_ct_kwh_brutto = _brutto(self.arbeitspreis_ct_kwh, faktor)
         if self.leistungspreis_eur_kw_jahr_brutto is None:
-            self.leistungspreis_eur_kw_jahr_brutto = _brutto(self.leistungspreis_eur_kw_jahr, faktor)
+            self.leistungspreis_eur_kw_jahr_brutto = _brutto(
+                self.leistungspreis_eur_kw_jahr, faktor
+            )
         if self.leistungspreis_eur_kw_monat_brutto is None:
-            self.leistungspreis_eur_kw_monat_brutto = _brutto(self.leistungspreis_eur_kw_monat, faktor)
+            self.leistungspreis_eur_kw_monat_brutto = _brutto(
+                self.leistungspreis_eur_kw_monat, faktor
+            )
 
     def as_dict(self) -> dict:
         return asdict(self)
 
 
 CSV_FIELDS = [
-    "stadt", "netzbetreiber", "netzbetreiber_typ", "netzebene", "tarifsystem",
-    "kundentyp", "benutzungsdauer_klasse",
-    "grundpreis_eur_jahr", "grundpreis_eur_jahr_brutto",
-    "arbeitspreis_ct_kwh", "arbeitspreis_ct_kwh_brutto",
-    "leistungspreis_eur_kw_jahr", "leistungspreis_eur_kw_jahr_brutto",
-    "leistungspreis_eur_kw_monat", "leistungspreis_eur_kw_monat_brutto",
-    "jahr", "stand_dokument", "quelle_url", "netto_oder_brutto", "mwst_prozent",
+    "stadt",
+    "netzbetreiber",
+    "netzbetreiber_typ",
+    "netzebene",
+    "tarifsystem",
+    "kundentyp",
+    "benutzungsdauer_klasse",
+    "grundpreis_eur_jahr",
+    "grundpreis_eur_jahr_brutto",
+    "arbeitspreis_ct_kwh",
+    "arbeitspreis_ct_kwh_brutto",
+    "leistungspreis_eur_kw_jahr",
+    "leistungspreis_eur_kw_jahr_brutto",
+    "leistungspreis_eur_kw_monat",
+    "leistungspreis_eur_kw_monat_brutto",
+    "jahr",
+    "stand_dokument",
+    "quelle_url",
+    "netto_oder_brutto",
+    "mwst_prozent",
 ]

--- a/oeds/crawler/netzentgelte/schema.py
+++ b/oeds/crawler/netzentgelte/schema.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Christoph Komanns
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Unified data model for electricity grid fees (Germany).
+
+Each row in the final output is a NetzentgeltEintrag: one city, one grid
+operator, one voltage level, one price component.
+
+Key terminology (see README):
+- "Niederspannung / Grundpreis-Arbeitspreissystem" -> the tariff for normal
+  household customers without interval metering.
+- "Niederspannung / Jahres-/Monatsleistungspreissystem" -> for commercial RLM
+  customers with interval metering, NOT for normal households.
+- Distribution voltage levels above low voltage (MS/NS transformation, medium
+  voltage, HS/MS transformation, high voltage) are included in the same
+  price sheet of the respective distribution operator (VNB).
+- The transmission grid (extra-high voltage + HÖS/HS transformation) has been
+  nationwide uniform since 2023 and does NOT depend on the individual city/VNB.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Optional
+
+# Canonical voltage level names, in order from generation/transmission to the
+# household connection.
+NETZEBENEN = [
+    "Hoechstspannung",            # HÖS - transmission grid
+    "Umspannung_HOES_HS",         # transmission/distribution boundary
+    "Hochspannung",               # HS - distribution grid
+    "Umspannung_HS_MS",           # distribution grid
+    "Mittelspannung",             # MS - distribution grid
+    "Umspannung_MS_NS",           # distribution grid
+    "Niederspannung",             # NS - distribution grid (household connection)
+]
+
+TARIFSYSTEME = [
+    "Grundpreis_Arbeitspreis",     # household customers / SLP without interval metering
+    "Jahresleistungspreis",        # RLM customers, annual capacity price system
+    "Monatsleistungspreis",        # RLM customers, monthly capacity price system
+]
+
+# Customer type per tariff system:
+# - SLP (Standardlastprofil): household/small customers without interval metering,
+#   billed via base price + energy price.
+# - RLM (registrierende Leistungsmessung): commercial/large customers with interval
+#   metering, billed via capacity and energy price.
+KUNDENTYP_JE_TARIFSYSTEM = {
+    "Grundpreis_Arbeitspreis": "SLP",
+    "Jahresleistungspreis": "RLM",
+    "Monatsleistungspreis": "RLM",
+}
+
+
+def _brutto(netto: Optional[float], faktor: float) -> Optional[float]:
+    """Compute gross value from net value (None stays None)."""
+    if netto is None:
+        return None
+    return round(netto * faktor, 5)
+
+
+@dataclass
+class NetzentgeltEintrag:
+    stadt: str                      # city requested by the user
+    netzbetreiber: str               # name of the grid operator (VNB or ÜNB)
+    netzbetreiber_typ: str           # "Verteilnetz" or "Uebertragungsnetz"
+    netzebene: str                   # one of NETZEBENEN
+    tarifsystem: str                 # one of TARIFSYSTEME
+    benutzungsdauer_klasse: Optional[str]  # "<2500h" / ">=2500h" / None
+    grundpreis_eur_jahr: Optional[float]
+    arbeitspreis_ct_kwh: Optional[float]
+    leistungspreis_eur_kw_jahr: Optional[float]
+    leistungspreis_eur_kw_monat: Optional[float]
+    jahr: int                        # validity year of the price sheet
+    stand_dokument: Optional[str]    # version/effective date per PDF
+    quelle_url: str
+    # Basis in which the source publishes the prices above.
+    netto_oder_brutto: str = "netto"
+    # VAT rate in percent for net<->gross conversion. Germany 19;
+    # foreign adapters differ (NL 21, BE 6).
+    mwst_prozent: float = 19.0
+    # Derived automatically from the tariff system in __post_init__.
+    kundentyp: Optional[str] = None
+    # Gross counterparts of the price components, computed in __post_init__.
+    grundpreis_eur_jahr_brutto: Optional[float] = None
+    arbeitspreis_ct_kwh_brutto: Optional[float] = None
+    leistungspreis_eur_kw_jahr_brutto: Optional[float] = None
+    leistungspreis_eur_kw_monat_brutto: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        if self.kundentyp is None:
+            self.kundentyp = KUNDENTYP_JE_TARIFSYSTEM.get(self.tarifsystem)
+        # Compute gross values. If the source already publishes gross amounts
+        # (e.g. NL/BE), the gross columns match the source values.
+        faktor = 1.0 if self.netto_oder_brutto == "brutto" else 1 + self.mwst_prozent / 100
+        if self.grundpreis_eur_jahr_brutto is None:
+            self.grundpreis_eur_jahr_brutto = _brutto(self.grundpreis_eur_jahr, faktor)
+        if self.arbeitspreis_ct_kwh_brutto is None:
+            self.arbeitspreis_ct_kwh_brutto = _brutto(self.arbeitspreis_ct_kwh, faktor)
+        if self.leistungspreis_eur_kw_jahr_brutto is None:
+            self.leistungspreis_eur_kw_jahr_brutto = _brutto(self.leistungspreis_eur_kw_jahr, faktor)
+        if self.leistungspreis_eur_kw_monat_brutto is None:
+            self.leistungspreis_eur_kw_monat_brutto = _brutto(self.leistungspreis_eur_kw_monat, faktor)
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+CSV_FIELDS = [
+    "stadt", "netzbetreiber", "netzbetreiber_typ", "netzebene", "tarifsystem",
+    "kundentyp", "benutzungsdauer_klasse",
+    "grundpreis_eur_jahr", "grundpreis_eur_jahr_brutto",
+    "arbeitspreis_ct_kwh", "arbeitspreis_ct_kwh_brutto",
+    "leistungspreis_eur_kw_jahr", "leistungspreis_eur_kw_jahr_brutto",
+    "leistungspreis_eur_kw_monat", "leistungspreis_eur_kw_monat_brutto",
+    "jahr", "stand_dokument", "quelle_url", "netto_oder_brutto", "mwst_prozent",
+]

--- a/oeds/crawler/netzentgelte/schema.py
+++ b/oeds/crawler/netzentgelte/schema.py
@@ -19,27 +19,27 @@ Key terminology (see README):
 - The transmission grid (extra-high voltage + HÖS/HS transformation) has been
   nationwide uniform since 2023 and does NOT depend on the individual city/VNB.
 """
-
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass, asdict
+from typing import Optional
 
 # Canonical voltage level names, in order from generation/transmission to the
 # household connection.
 NETZEBENEN = [
-    "Hoechstspannung",  # HÖS - transmission grid
-    "Umspannung_HOES_HS",  # transmission/distribution boundary
-    "Hochspannung",  # HS - distribution grid
-    "Umspannung_HS_MS",  # distribution grid
-    "Mittelspannung",  # MS - distribution grid
-    "Umspannung_MS_NS",  # distribution grid
-    "Niederspannung",  # NS - distribution grid (household connection)
+    "Hoechstspannung",            # HÖS - transmission grid
+    "Umspannung_HOES_HS",         # transmission/distribution boundary
+    "Hochspannung",               # HS - distribution grid
+    "Umspannung_HS_MS",           # distribution grid
+    "Mittelspannung",             # MS - distribution grid
+    "Umspannung_MS_NS",           # distribution grid
+    "Niederspannung",             # NS - distribution grid (household connection)
 ]
 
 TARIFSYSTEME = [
-    "Grundpreis_Arbeitspreis",  # household customers / SLP without interval metering
-    "Jahresleistungspreis",  # RLM customers, annual capacity price system
-    "Monatsleistungspreis",  # RLM customers, monthly capacity price system
+    "Grundpreis_Arbeitspreis",     # household customers / SLP without interval metering
+    "Jahresleistungspreis",        # RLM customers, annual capacity price system
+    "Monatsleistungspreis",        # RLM customers, monthly capacity price system
 ]
 
 # Customer type per tariff system:
@@ -54,7 +54,7 @@ KUNDENTYP_JE_TARIFSYSTEM = {
 }
 
 
-def _brutto(netto: float | None, faktor: float) -> float | None:
+def _brutto(netto: Optional[float], faktor: float) -> Optional[float]:
     """Compute gross value from net value (None stays None)."""
     if netto is None:
         return None
@@ -63,18 +63,18 @@ def _brutto(netto: float | None, faktor: float) -> float | None:
 
 @dataclass
 class NetzentgeltEintrag:
-    stadt: str  # city requested by the user
-    netzbetreiber: str  # name of the grid operator (VNB or ÜNB)
-    netzbetreiber_typ: str  # "Verteilnetz" or "Uebertragungsnetz"
-    netzebene: str  # one of NETZEBENEN
-    tarifsystem: str  # one of TARIFSYSTEME
-    benutzungsdauer_klasse: str | None  # "<2500h" / ">=2500h" / None
-    grundpreis_eur_jahr: float | None
-    arbeitspreis_ct_kwh: float | None
-    leistungspreis_eur_kw_jahr: float | None
-    leistungspreis_eur_kw_monat: float | None
-    jahr: int  # validity year of the price sheet
-    stand_dokument: str | None  # version/effective date per PDF
+    stadt: str                      # city requested by the user
+    netzbetreiber: str               # name of the grid operator (VNB or ÜNB)
+    netzbetreiber_typ: str           # "Verteilnetz" or "Uebertragungsnetz"
+    netzebene: str                   # one of NETZEBENEN
+    tarifsystem: str                 # one of TARIFSYSTEME
+    benutzungsdauer_klasse: Optional[str]  # "<2500h" / ">=2500h" / None
+    grundpreis_eur_jahr: Optional[float]
+    arbeitspreis_ct_kwh: Optional[float]
+    leistungspreis_eur_kw_jahr: Optional[float]
+    leistungspreis_eur_kw_monat: Optional[float]
+    jahr: int                        # validity year of the price sheet
+    stand_dokument: Optional[str]    # version/effective date per PDF
     quelle_url: str
     # Basis in which the source publishes the prices above.
     netto_oder_brutto: str = "netto"
@@ -82,57 +82,38 @@ class NetzentgeltEintrag:
     # foreign adapters differ (NL 21, BE 6).
     mwst_prozent: float = 19.0
     # Derived automatically from the tariff system in __post_init__.
-    kundentyp: str | None = None
+    kundentyp: Optional[str] = None
     # Gross counterparts of the price components, computed in __post_init__.
-    grundpreis_eur_jahr_brutto: float | None = None
-    arbeitspreis_ct_kwh_brutto: float | None = None
-    leistungspreis_eur_kw_jahr_brutto: float | None = None
-    leistungspreis_eur_kw_monat_brutto: float | None = None
+    grundpreis_eur_jahr_brutto: Optional[float] = None
+    arbeitspreis_ct_kwh_brutto: Optional[float] = None
+    leistungspreis_eur_kw_jahr_brutto: Optional[float] = None
+    leistungspreis_eur_kw_monat_brutto: Optional[float] = None
 
     def __post_init__(self) -> None:
         if self.kundentyp is None:
             self.kundentyp = KUNDENTYP_JE_TARIFSYSTEM.get(self.tarifsystem)
         # Compute gross values. If the source already publishes gross amounts
         # (e.g. NL/BE), the gross columns match the source values.
-        faktor = (
-            1.0 if self.netto_oder_brutto == "brutto" else 1 + self.mwst_prozent / 100
-        )
+        faktor = 1.0 if self.netto_oder_brutto == "brutto" else 1 + self.mwst_prozent / 100
         if self.grundpreis_eur_jahr_brutto is None:
             self.grundpreis_eur_jahr_brutto = _brutto(self.grundpreis_eur_jahr, faktor)
         if self.arbeitspreis_ct_kwh_brutto is None:
             self.arbeitspreis_ct_kwh_brutto = _brutto(self.arbeitspreis_ct_kwh, faktor)
         if self.leistungspreis_eur_kw_jahr_brutto is None:
-            self.leistungspreis_eur_kw_jahr_brutto = _brutto(
-                self.leistungspreis_eur_kw_jahr, faktor
-            )
+            self.leistungspreis_eur_kw_jahr_brutto = _brutto(self.leistungspreis_eur_kw_jahr, faktor)
         if self.leistungspreis_eur_kw_monat_brutto is None:
-            self.leistungspreis_eur_kw_monat_brutto = _brutto(
-                self.leistungspreis_eur_kw_monat, faktor
-            )
+            self.leistungspreis_eur_kw_monat_brutto = _brutto(self.leistungspreis_eur_kw_monat, faktor)
 
     def as_dict(self) -> dict:
         return asdict(self)
 
 
 CSV_FIELDS = [
-    "stadt",
-    "netzbetreiber",
-    "netzbetreiber_typ",
-    "netzebene",
-    "tarifsystem",
-    "kundentyp",
-    "benutzungsdauer_klasse",
-    "grundpreis_eur_jahr",
-    "grundpreis_eur_jahr_brutto",
-    "arbeitspreis_ct_kwh",
-    "arbeitspreis_ct_kwh_brutto",
-    "leistungspreis_eur_kw_jahr",
-    "leistungspreis_eur_kw_jahr_brutto",
-    "leistungspreis_eur_kw_monat",
-    "leistungspreis_eur_kw_monat_brutto",
-    "jahr",
-    "stand_dokument",
-    "quelle_url",
-    "netto_oder_brutto",
-    "mwst_prozent",
+    "stadt", "netzbetreiber", "netzbetreiber_typ", "netzebene", "tarifsystem",
+    "kundentyp", "benutzungsdauer_klasse",
+    "grundpreis_eur_jahr", "grundpreis_eur_jahr_brutto",
+    "arbeitspreis_ct_kwh", "arbeitspreis_ct_kwh_brutto",
+    "leistungspreis_eur_kw_jahr", "leistungspreis_eur_kw_jahr_brutto",
+    "leistungspreis_eur_kw_monat", "leistungspreis_eur_kw_monat_brutto",
+    "jahr", "stand_dokument", "quelle_url", "netto_oder_brutto", "mwst_prozent",
 ]

--- a/oeds/main.py
+++ b/oeds/main.py
@@ -13,6 +13,7 @@ from oeds.base_crawler import (
     empty_config,
     load_config,
 )
+from oeds.crawler import crawlers
 
 log = logging.getLogger("OEDS")
 log.setLevel(logging.INFO)
@@ -48,8 +49,6 @@ def cli(args=None):
     parsed_args = parser.parse_args(args)
 
     logging.basicConfig(level=parsed_args.loglevel)
-    from oeds.crawler import crawlers
-
     selected_crawlers = (
         parsed_args.crawler_list if parsed_args.crawler_list else list(crawlers.keys())
     )
@@ -74,8 +73,6 @@ def cli(args=None):
 
 if __name__ == "__main__":
     logging.basicConfig()
-    from oeds.crawler import crawlers
-
     config = load_config(Path(__file__).parent.parent / "config.yml")
     for schema_name, crawler_class in crawlers.items():
         crawler = crawler_class(schema_name, config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "numpy >=1.26.4",
     "python-dateutil >=2.8.2",
     "pandas >=2.0.0",
+    "pdfplumber >=0.11",
     "pyyaml >=6.0.2",
     "open-mastr >=0.15.0",
     "beautifulsoup4 >= 4.15.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ numpy
 openpyxl
 open-mastr
 pandas
+pdfplumber # for netzentgelte grid-fee price sheets (PDF)
 psycopg2-binary
 tzdata # for additional timezones like Europe/Kiev in entsoe
 py7zr<1


### PR DESCRIPTION
### **User description**
# Add `netzentgelte` crawler for German electricity grid fees

## Summary

This PR adds a new `netzentgelte` crawler that collects German electricity grid
fees (Netzentgelte) from the official price sheets and normalises them into a
single, unified table.

Unlike the existing `eon_grid_fees` crawler — which obtains grid fees
*indirectly* through the E.ON tariff calculator per postal code — this crawler
parses the **official price sheets directly**:

- the **nationwide transmission grid** price sheet (the four German TSOs
  50Hertz / Amprion / TenneT / TransnetBW have published a single, uniform
  price sheet since 2023), and
- the **distribution system operator (VNB)** price sheets per city.

The result is one normalised table where each row is
`city × grid operator × voltage level × price component`, with both net and
gross values.

## Why a vendored subpackage

The parsing logic originates from the standalone `netzentgelte` tool. There is
deliberately **no single universal parser** for all ~880 German distribution
operators: every operator publishes its price sheet in its own PDF layout, and
there is no free, machine-readable "postal code → grid operator" mapping. The
robust approach is therefore a small, tested adapter per operator plus a
hand-maintained city → operator → URL mapping.

To keep OEDS **independently installable and runnable** (a `../netzentgelte`
import would break for anyone installing OEDS on its own), the logic is
**vendored** as the `oeds.crawler.netzentgelte` subpackage rather than pulled in
as an external path dependency.

## What's included

New subpackage `oeds/crawler/netzentgelte/`:

| File | Purpose |
| --- | --- |
| `crawler.py` | `NetzentgeltCrawler(DownloadOnceCrawler)` — writes the `netzentgelte` table |
| `collect.py` | fetches + parses all price sheets, returns `(entries, warnings)` |
| `schema.py` | `NetzentgeltEintrag` data model + net→gross / SLP↔RLM derivation |
| `fetch_uebertragungsnetz.py` | generic parser for the nationwide TSO price sheet |
| `cities.yaml` | hand-maintained city → VNB → price sheet URL → adapter mapping |
| `adapters/*.py` | one small, verified parser per distribution operator |

Wiring:

- registered as `netzentgelte` in the crawler registry (`oeds/crawler/__init__.py`)
- `pdfplumber` added to `pyproject.toml` and `requirements.txt`

### Crawler design

`NetzentgeltCrawler` is a `DownloadOnceCrawler`: price sheets are structural,
annually published data (valid per calendar year). Re-running with
`recreate=True` (or for a new `jahr`) overwrites the table. Cities without a
configured adapter, failed downloads, and parser errors are collected as
warnings and logged — the crawler **never silently emits guessed numbers**; the
affected city is simply absent from the table.

### Resulting table `netzentgelte.netzentgelte`

One row per price component, columns:

`stadt`, `netzbetreiber`, `netzbetreiber_typ`, `netzebene`, `tarifsystem`,
`kundentyp` (SLP/RLM), `benutzungsdauer_klasse`,
`grundpreis_eur_jahr`(`_brutto`), `arbeitspreis_ct_kwh`(`_brutto`),
`leistungspreis_eur_kw_jahr`(`_brutto`), `leistungspreis_eur_kw_monat`(`_brutto`),
`jahr`, `stand_dokument`, `quelle_url`, `netto_oder_brutto`, `mwst_prozent`.

`kundentyp` makes the key distinction explicit: `SLP`
(Grundpreis/Arbeitspreis) is the tariff relevant to normal households; `RLM`
(Jahres-/Monatsleistungspreis) applies to metered commercial/large customers.

### Coverage (initial set, 2026 price sheets)

| City | Distribution operator | Adapter |
| --- | --- | --- |
| Berlin | Stromnetz Berlin GmbH | `stromnetz_berlin` |
| Jülich | Stadtwerke Jülich GmbH | `stadtwerke_juelich` |
| Aachen | Regionetz GmbH | `regionetz` |
| Köln | Rheinische NETZGesellschaft (RheinNetz) | `rheinnetz` |
| Düren | Leitungspartner GmbH | `leitungspartner` |
| Heerlen (NL) | Enexis Netbeheer B.V. | `enexis_heerlen` |
| Lüttich (BE) | RESA SA | `resa_luettich` |

Adding a city is a small, self-contained step: add an entry to `cities.yaml`
and a new `adapters/<name>.py` with a `parse(text, stadt, jahr, quelle_url)`
function.

## Companion change: lazy crawler loading

The crawler registry (`oeds/crawler/__init__.py`) was switched from **eager to
lazy loading**. Previously, importing `oeds.crawler` imported *every* crawler
module — and thus every (optional/heavy) third-party dependency — up front.
Now each crawler module is only imported when that crawler is actually
selected. This keeps the new `pdfplumber` dependency (and any other crawler's
deps) from being required just to list or run an unrelated crawler.

## How to run

```bash
pip install -e .
# writes the `netzentgelte` schema/table:
oeds --db="postgresql://opendata:opendata@localhost:6432/opendata?options=--search_path={DBNAME}" \
     --crawler-list netzentgelte
```

Requires real internet access (price sheets are PDFs on the operators'
websites / netztransparenz.de).

## Notes & limitations

- **Yearly maintenance:** for a new year, update the price sheet URLs in
  `cities.yaml` and the transmission grid URL in `fetch_uebertragungsnetz.py`
  (same maintenance as upstream). `DEFAULT_JAHR` is `2026`.
- **Foreign cities (Heerlen/Lüttich)** follow a structurally different
  (non-German) fee logic and only map approximately into the German schema
  (capacity-only NL tariff, Belgian CWaPE terms, different VAT, gross vs. net).
  The nationwide transmission rows apply to the German cities only. See the
  adapter docstrings for details.
- **License:** operators publish their price sheets under § 28 StromNEV (freely
  available); redistribution rules vary by operator. This is recorded in the
  crawler's `metadata_info`.

## Possible follow-ups

- Offline parser tests against saved price-sheet text excerpts (the upstream
  tool ships these fixtures; they can be re-added under `tests/`).
- Add more cities/adapters (e.g. München, Wuppertal — URLs are on file, adapters
  still to be written).


___

### **PR Type**
Enhancement


___

### **Description**
- Add `netzentgelte` grid-fee crawler pipeline

- Parse VNB PDFs via per-operator adapters

- Fetch nationwide ÜNB fees from `netztransparenz`

- Register crawler and add `pdfplumber`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cli["oeds CLI"] --> reg["oeds.crawler.crawlers registry"]
  reg -- "runs" --> nz["NetzentgeltCrawler"]
  nz -- "collect" --> ce["collect_entries()"]
  ce -- "download PDFs" --> pdf["requests + pdfplumber text"]
  ce -- "parse per VNB" --> ad["Adapters (Berlin, Köln, etc.)"]
  ce -- "parse nationwide" --> uenb["ÜNB parser (fetch_uenb_entries)"]
  nz -- "write" --> db["DB table netzentgelte"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Register `NetzentgeltCrawler` in crawler registry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-0f49a621903cf626c2af77f6b268377b73179c8d55bfb5a4887d0c9121b3f165">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Export crawler and metadata for package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-02c3d06a74f6161cf08459c66162d83cc1b397fc18711b0b5113f91bf48663a7">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>_common.py</strong><dd><code>Add shared PDF text parsing helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-70a2c22f367b293def2e59ee3100fe841302b8ff8b9077d63c7ef024afa2c873">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>enexis_heerlen.py</strong><dd><code>Add Enexis Heerlen (NL) adapter parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-003d6f67a3cfa44cbc28c81f3db90edfd38f8fa484f7279e76e40c6bd870cfda">+82/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>leitungspartner.py</strong><dd><code>Add Leitungspartner adapter for Düren/Merzenich</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-66ce983fbe34a0a0ec636899820ceebee4d5ca61bb0d7777fecea84a6abfb1a0">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>regionetz.py</strong><dd><code>Add Regionetz adapter for Aachen region</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-c42ce7fad8c24168bc40285b2b817ed8b735c5b9a7c642fd0f1294412b8daa6c">+105/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>resa_luettich.py</strong><dd><code>Add RESA Liège (BE) tariff adapter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-90d7ef87f975c1c6e123e2713497729568fddd9e62306d247f6a254c7c20cb34">+82/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rheinnetz.py</strong><dd><code>Add RheinNetz adapter for Cologne PDFs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-2a47b1cdd2cd011bc54d92ce19c777c82169715138a77714c2bf7c380259a4fa">+105/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>stadtwerke_juelich.py</strong><dd><code>Add Stadtwerke Jülich adapter for tariffs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-b48c889d0245eafcfffacb046b42b1f075d66dc2dcb8798ea82a055ac036fbc7">+105/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>stromnetz_berlin.py</strong><dd><code>Add Stromnetz Berlin EDI-format parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-ca25a47a86c09505f19bdf5008719cddd8f7ee9d7560e2c81732a3a8887bbb23">+144/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>collect.py</strong><dd><code>Implement PDF download and entry collection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-93a64a715eb72ea8c3901433a023ea512b1198eacb737ff50b8251f4682ef607">+142/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>crawler.py</strong><dd><code>Add `DownloadOnceCrawler` writing `netzentgelte` table</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-3bf0f7d4722dcf6ddf192ba3e4e4e566f7213c29223d361b56ca9bf3be698b34">+118/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>fetch_uebertragungsnetz.py</strong><dd><code>Fetch and parse nationwide ÜNB PDF fees</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-d14a7aeedb30532f8b545fbda8235210cbc8e20a726575af3289138487483eee">+168/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>schema.py</strong><dd><code>Define unified schema and gross calculations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-2f55812bee9cd5ea9a649cad119926282befd2f6cc1ef79791affab868024570">+138/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Add adapters package with license headers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-5cd937ef4bdb46581eb838323a1840348a9239ce4aea0b930f1cf44421496de2">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Import crawler registry at module level</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-350aeb6f819976c9bc435f1d9f9143b0b0b379b03dd6c76b6791a01e74441f2d">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>cities.yaml</strong><dd><code>Add city-to-VNB mappings and price sheet URLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-fb826c1606b6a0d42101106406bca987a470c6fa11cecdb09823521b1bea2ea7">+75/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>pyproject.toml</strong><dd><code>Add `pdfplumber` dependency for PDF parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>requirements.txt</strong><dd><code>Add `pdfplumber` to runtime requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/open-energy-data-server/open-energy-data-server/pull/49/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

